### PR TITLE
Fix quantity input not refreshing in POS transaction page

### DIFF
--- a/application/controllers/Pos.php
+++ b/application/controllers/Pos.php
@@ -98,15 +98,22 @@ class Pos extends CI_Controller
         if (!$product) {
             redirect('pos');
         }
+        $qty = (int) $this->input->post('qty');
+        if (!$qty) {
+            $qty = (int) $this->input->get('qty');
+        }
+        if ($qty < 1) {
+            $qty = 1;
+        }
         $cart = $this->session->userdata('cart') ?: [];
         if (isset($cart[$id])) {
-            $cart[$id]['qty'] += 1;
+            $cart[$id]['qty'] += $qty;
         } else {
             $cart[$id] = [
                 'id'         => $product->id,
                 'nama_produk'=> $product->nama_produk,
                 'harga_jual' => $product->harga_jual,
-                'qty'        => 1
+                'qty'        => $qty
             ];
         }
         $this->session->set_userdata('cart', $cart);

--- a/application/views/pos/index.php
+++ b/application/views/pos/index.php
@@ -26,6 +26,7 @@
                     <th>Produk</th>
                     <th>Harga</th>
                     <th>Kategori</th>
+                    <th>Qty</th>
                     <th></th>
                 </tr>
             </thead>
@@ -35,7 +36,8 @@
                     <td><?php echo htmlspecialchars($p->nama_produk); ?></td>
                     <td>Rp <?php echo number_format($p->harga_jual, 0, ',', '.'); ?></td>
                     <td><?php echo htmlspecialchars($p->kategori); ?></td>
-                    <td><a href="<?php echo site_url('pos/add/'.$p->id); ?>" class="btn btn-sm btn-success">Tambah</a></td>
+                    <td><input type="number" value="1" min="1" class="form-control form-control-sm product-qty" data-id="<?php echo $p->id; ?>"></td>
+                    <td><button type="button" class="btn btn-sm btn-success add-to-cart" data-id="<?php echo $p->id; ?>">Tambah</button></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>
@@ -154,14 +156,16 @@ var addUrl = '<?php echo site_url('pos/add/'); ?>';
 
 function renderProducts(items) {
     productsBody.innerHTML = '';
-    items.forEach(function(p) {
+    for (var i = 0; i < items.length; i++) {
+        var p = items[i];
         var tr = document.createElement('tr');
         tr.innerHTML = '<td>' + p.nama_produk + '</td>' +
                        '<td>Rp ' + Number(p.harga_jual).toLocaleString('id-ID') + '</td>' +
                        '<td>' + p.kategori + '</td>' +
-                       '<td><a href="' + addUrl + p.id + '" class="btn btn-sm btn-success">Tambah</a></td>';
+                       '<td><input type="number" value="1" min="1" class="form-control form-control-sm product-qty" data-id="' + p.id + '"></td>' +
+                       '<td><button type="button" class="btn btn-sm btn-success add-to-cart" data-id="' + p.id + '">Tambah</button></td>';
         productsBody.appendChild(tr);
-    });
+    }
 }
 
 function updateProducts() {
@@ -183,28 +187,30 @@ var totalCell = document.getElementById('cart-total');
 
 function recalcTotal() {
     var total = 0;
-    qtyInputs.forEach(function(input) {
-        var price = parseFloat(input.dataset.price);
+    for (var i = 0; i < qtyInputs.length; i++) {
+        var input = qtyInputs[i];
+        var price = parseFloat(input.getAttribute('data-price'));
         var qty = parseFloat(input.value) || 0;
         total += price * qty;
-    });
+    }
     if (totalCell) {
         totalCell.textContent = 'Rp ' + total.toLocaleString('id-ID');
     }
 }
 
-qtyInputs.forEach(function(input) {
-    input.addEventListener('input', function() {
-        var price = parseFloat(this.dataset.price);
+for (var i = 0; i < qtyInputs.length; i++) {
+    qtyInputs[i].addEventListener('input', function() {
+        var price = parseFloat(this.getAttribute('data-price'));
         var qty = parseFloat(this.value) || 0;
         var subtotal = price * qty;
-        var cell = this.closest('tr').querySelector('.subtotal');
+        var row = this.parentNode.parentNode;
+        var cell = row.querySelector('.subtotal');
         if (cell) {
             cell.textContent = 'Rp ' + subtotal.toLocaleString('id-ID');
         }
         recalcTotal();
     });
-});
+}
 var memberSearchInput = document.getElementById('member-search');
 var memberSearchBtn = document.getElementById('member-search-btn');
 var memberTableBody = document.querySelector('#member-table tbody');
@@ -242,6 +248,12 @@ document.addEventListener('click', function(e) {
         document.getElementById('customer-id').value = id;
         document.getElementById('customer-name').value = name;
         $('#memberModal').modal('hide');
+    } else if (e.target.classList.contains('add-to-cart')) {
+        var pid = e.target.getAttribute('data-id');
+        var qtyInput = document.querySelector('input.product-qty[data-id="' + pid + '"]');
+        var qty = qtyInput ? parseInt(qtyInput.value, 10) : 1;
+        if (!qty || qty < 1) { qty = 1; }
+        window.location.href = addUrl + pid + '?qty=' + qty;
     }
 });
 


### PR DESCRIPTION
## Summary
- add quantity field next to the add button so cashiers can set units before adding to cart
- send selected quantity with new add-to-cart handler and server-side support

## Testing
- `php -l application/views/pos/index.php`
- `php -l application/controllers/Pos.php`
- `composer test:coverage` *(fails: phpunit: not found)*
- `composer install` *(fails: CONNECT tunnel failed: 403)*


------
https://chatgpt.com/codex/tasks/task_e_68aff8d8add08320887202695b98002d