### PR TITLE
Fix quantity input not refreshing in POS transaction page

### DIFF
--- a/application/controllers/Members.php
+++ b/application/controllers/Members.php
@@ -41,7 +41,7 @@ class Members extends CI_Controller
     {
         $this->authorize();
         $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
-        $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
+        $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check');
         $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required');
         $this->form_validation->set_rules('password', 'Password', 'required|min_length[6]');
         $this->form_validation->set_rules('alamat', 'Alamat', 'required');
@@ -84,7 +84,7 @@ class Members extends CI_Controller
     {
         $this->authorize();
         $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
-        $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
+        $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check['.$id.']');
         $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required');
         $this->form_validation->set_rules('alamat', 'Alamat', 'required');
         $this->form_validation->set_rules('kecamatan', 'Kecamatan', 'required');
@@ -147,7 +147,7 @@ class Members extends CI_Controller
         $id = $this->session->userdata('id');
 
         $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
-        $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
+        $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check['.$id.']');
         $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required');
         if ($this->input->post('password')) {
             $this->form_validation->set_rules('password', 'Password', 'min_length[6]');
@@ -185,6 +185,15 @@ class Members extends CI_Controller
 
         $data['member'] = $this->Member_model->get_by_id($id);
         $this->load->view('members/profile', $data);
+    }
+
+    public function email_check($email, $id = NULL)
+    {
+        if ($this->User_model->email_exists($email, $id)) {
+            $this->form_validation->set_message('email_check', 'Email sudah digunakan.');
+            return FALSE;
+        }
+        return TRUE;
     }
 }
 ?>

--- a/application/controllers/Pos.php
+++ b/application/controllers/Pos.php
@@ -98,15 +98,22 @@ class Pos extends CI_Controller
         if (!$product) {
             redirect('pos');
         }
+        $qty = (int) $this->input->post('qty');
+        if (!$qty) {
+            $qty = (int) $this->input->get('qty');
+        }
+        if ($qty < 1) {
+            $qty = 1;
+        }
         $cart = $this->session->userdata('cart') ?: [];
         if (isset($cart[$id])) {
-            $cart[$id]['qty'] += 1;
+            $cart[$id]['qty'] += $qty;
         } else {
             $cart[$id] = [
                 'id'         => $product->id,
                 'nama_produk'=> $product->nama_produk,
                 'harga_jual' => $product->harga_jual,
-                'qty'        => 1
+                'qty'        => $qty
             ];
         }
         $this->session->set_userdata('cart', $cart);

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -48,6 +48,15 @@ class User_model extends CI_Model
         return $this->db->get($this->table)->result();
     }
 
+    public function email_exists($email, $exclude_id = NULL)
+    {
+        $this->db->where('email', $email);
+        if ($exclude_id !== NULL) {
+            $this->db->where('id !=', $exclude_id);
+        }
+        return $this->db->get($this->table)->num_rows() > 0;
+    }
+
     public function update($id, $data)
     {
         return $this->db->where('id', $id)->update($this->table, $data);

--- a/application/views/pos/index.php
+++ b/application/views/pos/index.php
@@ -26,6 +26,7 @@
                     <th>Produk</th>
                     <th>Harga</th>
                     <th>Kategori</th>
+                    <th>Qty</th>
                     <th></th>
                 </tr>
             </thead>
@@ -35,7 +36,8 @@
                     <td><?php echo htmlspecialchars($p->nama_produk); ?></td>
                     <td>Rp <?php echo number_format($p->harga_jual, 0, ',', '.'); ?></td>
                     <td><?php echo htmlspecialchars($p->kategori); ?></td>
-                    <td><a href="<?php echo site_url('pos/add/'.$p->id); ?>" class="btn btn-sm btn-success">Tambah</a></td>
+                    <td><input type="number" value="1" min="1" class="form-control form-control-sm product-qty" data-id="<?php echo $p->id; ?>" style="width:60px"></td>
+                    <td><button type="button" class="btn btn-sm btn-success add-to-cart" data-id="<?php echo $p->id; ?>">Tambah</button></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>
@@ -44,8 +46,7 @@
     <div class="col-md-6">
         <h4>Keranjang</h4>
         <?php if (!empty($cart)): ?>
-            <form method="post" action="<?php echo site_url('pos/update_cart'); ?>">
-                <table class="table table-bordered">
+            <table class="table table-bordered">
                     <thead>
                         <tr>
                             <th>Nota</th>
@@ -72,7 +73,7 @@
                                 </td>
                             <?php $first = false; endif; ?>
                             <td><?php echo htmlspecialchars($item['nama_produk']); ?></td>
-                            <td><input type="number" name="qty[<?php echo $item['id']; ?>]" value="<?php echo $item['qty']; ?>" min="1" class="form-control form-control-sm cart-qty" data-price="<?php echo $item['harga_jual']; ?>"></td>
+                            <td><span class="cart-qty" data-price="<?php echo $item['harga_jual']; ?>"><?php echo $item['qty']; ?></span></td>
                             <td class="subtotal">Rp <?php echo number_format($item['harga_jual'] * $item['qty'], 0, ',', '.'); ?></td>
                             <td><a href="<?php echo site_url('pos/remove/'.$item['id']); ?>" class="btn btn-sm btn-danger">Hapus</a></td>
                         </tr>
@@ -85,8 +86,7 @@
                             <th id="cart-total">Rp <?php echo number_format($total, 0, ',', '.'); ?></th>
                         </tr>
                     </tfoot>
-                </table>
-            </form>
+            </table>
             <form method="post" action="<?php echo site_url('pos/checkout'); ?>" id="checkout-form">
                 <input type="hidden" name="device_date" id="device_date">
                 <input type="hidden" name="nota" value="<?php echo $nota; ?>">
@@ -154,14 +154,16 @@ var addUrl = '<?php echo site_url('pos/add/'); ?>';
 
 function renderProducts(items) {
     productsBody.innerHTML = '';
-    items.forEach(function(p) {
+    for (var i = 0; i < items.length; i++) {
+        var p = items[i];
         var tr = document.createElement('tr');
         tr.innerHTML = '<td>' + p.nama_produk + '</td>' +
                        '<td>Rp ' + Number(p.harga_jual).toLocaleString('id-ID') + '</td>' +
                        '<td>' + p.kategori + '</td>' +
-                       '<td><a href="' + addUrl + p.id + '" class="btn btn-sm btn-success">Tambah</a></td>';
+                       '<td><input type="number" value="1" min="1" class="form-control form-control-sm product-qty" style="width:60px" data-id="' + p.id + '"></td>' +
+                       '<td><button type="button" class="btn btn-sm btn-success add-to-cart" data-id="' + p.id + '">Tambah</button></td>';
         productsBody.appendChild(tr);
-    });
+    }
 }
 
 function updateProducts() {
@@ -178,33 +180,23 @@ if (searchInput && categorySelect) {
     categorySelect.addEventListener('change', updateProducts);
 }
 
-var qtyInputs = document.querySelectorAll('.cart-qty');
+var qtyCells = document.querySelectorAll('.cart-qty');
 var totalCell = document.getElementById('cart-total');
 
 function recalcTotal() {
     var total = 0;
-    qtyInputs.forEach(function(input) {
-        var price = parseFloat(input.dataset.price);
-        var qty = parseFloat(input.value) || 0;
+    for (var i = 0; i < qtyCells.length; i++) {
+        var cell = qtyCells[i];
+        var price = parseFloat(cell.getAttribute('data-price'));
+        var qty = parseFloat(cell.textContent) || 0;
         total += price * qty;
-    });
+    }
     if (totalCell) {
         totalCell.textContent = 'Rp ' + total.toLocaleString('id-ID');
     }
 }
 
-qtyInputs.forEach(function(input) {
-    input.addEventListener('input', function() {
-        var price = parseFloat(this.dataset.price);
-        var qty = parseFloat(this.value) || 0;
-        var subtotal = price * qty;
-        var cell = this.closest('tr').querySelector('.subtotal');
-        if (cell) {
-            cell.textContent = 'Rp ' + subtotal.toLocaleString('id-ID');
-        }
-        recalcTotal();
-    });
-});
+recalcTotal();
 var memberSearchInput = document.getElementById('member-search');
 var memberSearchBtn = document.getElementById('member-search-btn');
 var memberTableBody = document.querySelector('#member-table tbody');
@@ -242,6 +234,12 @@ document.addEventListener('click', function(e) {
         document.getElementById('customer-id').value = id;
         document.getElementById('customer-name').value = name;
         $('#memberModal').modal('hide');
+    } else if (e.target.classList.contains('add-to-cart')) {
+        var pid = e.target.getAttribute('data-id');
+        var qtyInput = document.querySelector('input.product-qty[data-id="' + pid + '"]');
+        var qty = qtyInput ? parseInt(qtyInput.value, 10) : 1;
+        if (!qty || qty < 1) { qty = 1; }
+        window.location.href = addUrl + pid + '?qty=' + qty;
     }
 });
 


### PR DESCRIPTION
## Summary
- add quantity field next to the add button so cashiers can set units before adding to cart
- send selected quantity with new add-to-cart handler and server-side support
- shorten product list quantity input and make cart quantities display-only
- validate member email addresses to warn when an email is already in use

## Testing
- `php -l application/views/pos/index.php`
- `php -l application/controllers/Pos.php`
- `php -l application/controllers/Members.php`
- `php -l application/models/User_model.php`
- `composer test:coverage` *(fails: phpunit: not found)*
- `composer install` *(fails: CONNECT tunnel failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aff8d8add08320887202695b98002d