### PR TITLE
Enforce unique contact info and add 'BON OWNER' cash category

### DIFF
--- a/application/controllers/Auth.php
+++ b/application/controllers/Auth.php
@@ -64,7 +64,12 @@ class Auth extends CI_Controller
 
         if ($this->input->method() === 'post') {
             $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
-            $this->form_validation->set_rules('email', 'Email', 'required|valid_email|is_unique[users.email]');
+            $this->form_validation->set_rules('email', 'Email', 'required|valid_email|is_unique[users.email]', [
+                'is_unique' => 'Email sudah digunakan.'
+            ]);
+            $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|is_unique[users.no_telepon]', [
+                'is_unique' => 'No telepon sudah digunakan.'
+            ]);
             $this->form_validation->set_rules('password', 'Password', 'required|min_length[6]');
             $this->form_validation->set_rules('password_confirm', 'Konfirmasi Password', 'required|matches[password]');
 

--- a/application/controllers/Members.php
+++ b/application/controllers/Members.php
@@ -41,8 +41,8 @@ class Members extends CI_Controller
     {
         $this->authorize();
         $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
-        $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
-        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required');
+        $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check');
+        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|callback_phone_check');
         $this->form_validation->set_rules('password', 'Password', 'required|min_length[6]');
         $this->form_validation->set_rules('alamat', 'Alamat', 'required');
         $this->form_validation->set_rules('kecamatan', 'Kecamatan', 'required');
@@ -84,8 +84,8 @@ class Members extends CI_Controller
     {
         $this->authorize();
         $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
-        $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
-        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required');
+        $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check['.$id.']');
+        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|callback_phone_check['.$id.']');
         $this->form_validation->set_rules('alamat', 'Alamat', 'required');
         $this->form_validation->set_rules('kecamatan', 'Kecamatan', 'required');
         $this->form_validation->set_rules('kota', 'Kota', 'required');
@@ -147,8 +147,8 @@ class Members extends CI_Controller
         $id = $this->session->userdata('id');
 
         $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
-        $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
-        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required');
+        $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check['.$id.']');
+        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|callback_phone_check['.$id.']');
         if ($this->input->post('password')) {
             $this->form_validation->set_rules('password', 'Password', 'min_length[6]');
         }
@@ -185,6 +185,24 @@ class Members extends CI_Controller
 
         $data['member'] = $this->Member_model->get_by_id($id);
         $this->load->view('members/profile', $data);
+    }
+
+    public function email_check($email, $id = NULL)
+    {
+        if ($this->User_model->email_exists($email, $id)) {
+            $this->form_validation->set_message('email_check', 'Email sudah digunakan.');
+            return FALSE;
+        }
+        return TRUE;
+    }
+
+    public function phone_check($no_telepon, $id = NULL)
+    {
+        if ($this->User_model->phone_exists($no_telepon, $id)) {
+            $this->form_validation->set_message('phone_check', 'No telepon sudah digunakan.');
+            return FALSE;
+        }
+        return TRUE;
     }
 }
 ?>

--- a/application/models/Member_model.php
+++ b/application/models/Member_model.php
@@ -40,6 +40,18 @@ class Member_model extends CI_Model
     }
 
     /**
+     * Ambil satu member berdasarkan kode member.
+     */
+    public function get_by_kode($kode)
+    {
+        $this->db->select('u.id, u.nama_lengkap, u.no_telepon, m.alamat');
+        $this->db->from('users u');
+        $this->db->join('member_data m', 'm.user_id = u.id', 'left');
+        $this->db->where(['m.kode_member' => $kode, 'u.role' => 'pelanggan']);
+        return $this->db->get()->row();
+    }
+
+    /**
      * Ambil satu member berdasarkan ID user.
      */
     public function get_by_id($id)

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -48,6 +48,24 @@ class User_model extends CI_Model
         return $this->db->get($this->table)->result();
     }
 
+    public function email_exists($email, $exclude_id = NULL)
+    {
+        $this->db->where('email', $email);
+        if ($exclude_id !== NULL) {
+            $this->db->where('id !=', $exclude_id);
+        }
+        return $this->db->get($this->table)->num_rows() > 0;
+    }
+
+    public function phone_exists($no_telepon, $exclude_id = NULL)
+    {
+        $this->db->where('no_telepon', $no_telepon);
+        if ($exclude_id !== NULL) {
+            $this->db->where('id !=', $exclude_id);
+        }
+        return $this->db->get($this->table)->num_rows() > 0;
+    }
+
     public function update($id, $data)
     {
         return $this->db->where('id', $id)->update($this->table, $data);

--- a/application/views/auth/register.php
+++ b/application/views/auth/register.php
@@ -17,7 +17,7 @@
     </div>
     <div class="form-group">
         <label for="no_telepon">No. Telepon</label>
-        <input type="text" class="form-control" id="no_telepon" name="no_telepon" value="<?php echo set_value('no_telepon'); ?>">
+        <input type="text" class="form-control" id="no_telepon" name="no_telepon" value="<?php echo set_value('no_telepon'); ?>" required>
     </div>
     <div class="form-group">
         <label for="password">Password</label>

--- a/application/views/cash/add.php
+++ b/application/views/cash/add.php
@@ -14,6 +14,7 @@
         <select name="category" id="category" class="form-control">
             <option value="BON OPERASIONAL">BON OPERASIONAL</option>
             <option value="BON TRANSFER BANK">BON TRANSFER BANK</option>
+            <option value="BON OWNER">BON OWNER</option>
             <option value="DEBIT CREDIT CARD">DEBIT CREDIT CARD</option>
             <option value="MODAL">MODAL</option>
         </select>

--- a/application/views/cash/withdraw.php
+++ b/application/views/cash/withdraw.php
@@ -14,6 +14,7 @@
         <select name="category" id="category" class="form-control">
             <option value="BON OPERASIONAL">BON OPERASIONAL</option>
             <option value="BON TRANSFER BANK">BON TRANSFER BANK</option>
+            <option value="BON OWNER">BON OWNER</option>
             <option value="DEBIT CREDIT CARD">DEBIT CREDIT CARD</option>
             <option value="MODAL">MODAL</option>
         </select>

--- a/application/views/pos/index.php
+++ b/application/views/pos/index.php
@@ -26,6 +26,7 @@
                     <th>Produk</th>
                     <th>Harga</th>
                     <th>Kategori</th>
+                    <th>Qty</th>
                     <th></th>
                 </tr>
             </thead>
@@ -35,7 +36,8 @@
                     <td><?php echo htmlspecialchars($p->nama_produk); ?></td>
                     <td>Rp <?php echo number_format($p->harga_jual, 0, ',', '.'); ?></td>
                     <td><?php echo htmlspecialchars($p->kategori); ?></td>
-                    <td><a href="<?php echo site_url('pos/add/'.$p->id); ?>" class="btn btn-sm btn-success">Tambah</a></td>
+                    <td><input type="number" value="1" min="1" class="form-control form-control-sm product-qty" data-id="<?php echo $p->id; ?>" style="width:60px"></td>
+                    <td><button type="button" class="btn btn-sm btn-success add-to-cart" data-id="<?php echo $p->id; ?>">Tambah</button></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>
@@ -44,8 +46,7 @@
     <div class="col-md-6">
         <h4>Keranjang</h4>
         <?php if (!empty($cart)): ?>
-            <form method="post" action="<?php echo site_url('pos/update_cart'); ?>">
-                <table class="table table-bordered">
+            <table class="table table-bordered">
                     <thead>
                         <tr>
                             <th>Nota</th>
@@ -72,7 +73,7 @@
                                 </td>
                             <?php $first = false; endif; ?>
                             <td><?php echo htmlspecialchars($item['nama_produk']); ?></td>
-                            <td><input type="number" name="qty[<?php echo $item['id']; ?>]" value="<?php echo $item['qty']; ?>" min="1" class="form-control form-control-sm cart-qty" data-price="<?php echo $item['harga_jual']; ?>"></td>
+                            <td><span class="cart-qty" data-price="<?php echo $item['harga_jual']; ?>"><?php echo $item['qty']; ?></span></td>
                             <td class="subtotal">Rp <?php echo number_format($item['harga_jual'] * $item['qty'], 0, ',', '.'); ?></td>
                             <td><a href="<?php echo site_url('pos/remove/'.$item['id']); ?>" class="btn btn-sm btn-danger">Hapus</a></td>
                         </tr>
@@ -85,8 +86,7 @@
                             <th id="cart-total">Rp <?php echo number_format($total, 0, ',', '.'); ?></th>
                         </tr>
                     </tfoot>
-                </table>
-            </form>
+            </table>
             <form method="post" action="<?php echo site_url('pos/checkout'); ?>" id="checkout-form">
                 <input type="hidden" name="device_date" id="device_date">
                 <input type="hidden" name="nota" value="<?php echo $nota; ?>">
@@ -109,30 +109,32 @@
         </button>
       </div>
       <div class="modal-body">
-        <div class="form-inline mb-2">
-          <input type="text" id="member-search" class="form-control mr-2" placeholder="Cari customer">
-          <button type="button" id="member-search-btn" class="btn btn-primary btn-sm">Cari</button>
+        <div class="form-group">
+          <label for="customer-type">Pilihan</label>
+          <select id="customer-type" class="form-control">
+            <option value="non">Non Member</option>
+            <option value="member">Member</option>
+          </select>
         </div>
-        <table class="table table-bordered table-sm" id="member-table">
-          <thead>
-            <tr>
-              <th>Kode</th>
-              <th>Nama</th>
-              <th>Telepon</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-          <?php foreach ($members as $m): ?>
-            <tr>
-              <td><?php echo htmlspecialchars($m->kode_member); ?></td>
-              <td><?php echo htmlspecialchars($m->nama_lengkap); ?></td>
-              <td><?php echo htmlspecialchars($m->no_telepon); ?></td>
-              <td><button type="button" class="btn btn-sm btn-success select-member" data-id="<?php echo $m->id; ?>" data-name="<?php echo htmlspecialchars($m->nama_lengkap); ?>">Pilih</button></td>
-            </tr>
-          <?php endforeach; ?>
-          </tbody>
-        </table>
+        <div class="form-group">
+          <label for="member-number">Nomor Member</label>
+          <input type="text" id="member-number" class="form-control" disabled>
+        </div>
+        <div class="form-group">
+          <label for="modal-name">Nama</label>
+          <input type="text" id="modal-name" class="form-control">
+        </div>
+        <div class="form-group">
+          <label for="modal-phone">No Telepon</label>
+          <input type="text" id="modal-phone" class="form-control">
+        </div>
+        <div class="form-group">
+          <label for="modal-address">Alamat</label>
+          <textarea id="modal-address" class="form-control"></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" id="choose-member">Pilih</button>
       </div>
     </div>
   </div>
@@ -154,14 +156,16 @@ var addUrl = '<?php echo site_url('pos/add/'); ?>';
 
 function renderProducts(items) {
     productsBody.innerHTML = '';
-    items.forEach(function(p) {
+    for (var i = 0; i < items.length; i++) {
+        var p = items[i];
         var tr = document.createElement('tr');
         tr.innerHTML = '<td>' + p.nama_produk + '</td>' +
                        '<td>Rp ' + Number(p.harga_jual).toLocaleString('id-ID') + '</td>' +
                        '<td>' + p.kategori + '</td>' +
-                       '<td><a href="' + addUrl + p.id + '" class="btn btn-sm btn-success">Tambah</a></td>';
+                       '<td><input type="number" value="1" min="1" class="form-control form-control-sm product-qty" style="width:60px" data-id="' + p.id + '"></td>' +
+                       '<td><button type="button" class="btn btn-sm btn-success add-to-cart" data-id="' + p.id + '">Tambah</button></td>';
         productsBody.appendChild(tr);
-    });
+    }
 }
 
 function updateProducts() {
@@ -178,82 +182,107 @@ if (searchInput && categorySelect) {
     categorySelect.addEventListener('change', updateProducts);
 }
 
-var qtyInputs = document.querySelectorAll('.cart-qty');
+var qtyCells = document.querySelectorAll('.cart-qty');
 var totalCell = document.getElementById('cart-total');
 
 function recalcTotal() {
     var total = 0;
-    qtyInputs.forEach(function(input) {
-        var price = parseFloat(input.dataset.price);
-        var qty = parseFloat(input.value) || 0;
+    for (var i = 0; i < qtyCells.length; i++) {
+        var cell = qtyCells[i];
+        var price = parseFloat(cell.getAttribute('data-price'));
+        var qty = parseFloat(cell.textContent) || 0;
         total += price * qty;
-    });
+    }
     if (totalCell) {
         totalCell.textContent = 'Rp ' + total.toLocaleString('id-ID');
     }
 }
 
-qtyInputs.forEach(function(input) {
-    input.addEventListener('input', function() {
-        var price = parseFloat(this.dataset.price);
-        var qty = parseFloat(this.value) || 0;
-        var subtotal = price * qty;
-        var cell = this.closest('tr').querySelector('.subtotal');
-        if (cell) {
-            cell.textContent = 'Rp ' + subtotal.toLocaleString('id-ID');
+recalcTotal();
+
+var typeSelect = document.getElementById('customer-type');
+var numberInput = document.getElementById('member-number');
+var nameInput = document.getElementById('modal-name');
+var phoneInput = document.getElementById('modal-phone');
+var addressInput = document.getElementById('modal-address');
+var chooseBtn = document.getElementById('choose-member');
+var lookupUrl = '<?php echo site_url('pos/member_lookup'); ?>';
+
+if (typeSelect && typeSelect.value === 'non') {
+    numberInput.value = 'non member';
+    document.getElementById('customer-id').value = 'non member';
+}
+
+if (typeSelect) {
+    typeSelect.addEventListener('change', function() {
+        if (this.value === 'member') {
+            numberInput.disabled = false;
+            numberInput.value = '';
+            nameInput.readOnly = true;
+            phoneInput.readOnly = true;
+            addressInput.readOnly = true;
+            nameInput.value = '';
+            phoneInput.value = '';
+            addressInput.value = '';
+            document.getElementById('customer-id').value = '';
+            numberInput.focus();
+        } else {
+            numberInput.value = 'non member';
+            numberInput.disabled = true;
+            nameInput.readOnly = false;
+            phoneInput.readOnly = false;
+            addressInput.readOnly = false;
+            nameInput.value = '';
+            phoneInput.value = '';
+            addressInput.value = '';
+            document.getElementById('customer-id').value = 'non member';
         }
-        recalcTotal();
-    });
-});
-var memberSearchInput = document.getElementById('member-search');
-var memberSearchBtn = document.getElementById('member-search-btn');
-var memberTableBody = document.querySelector('#member-table tbody');
-var memberSearchUrl = '<?php echo site_url('pos/member_search'); ?>';
-
-function renderMembers(list) {
-    memberTableBody.innerHTML = '';
-    list.forEach(function(m) {
-        var tr = document.createElement('tr');
-        tr.innerHTML = '<td>' + (m.kode_member || '') + '</td>' +
-                       '<td>' + m.nama_lengkap + '</td>' +
-                       '<td>' + (m.no_telepon || '') + '</td>' +
-                       '<td><button type="button" class="btn btn-sm btn-success select-member" data-id="' + m.id + '" data-name="' + m.nama_lengkap + '">Pilih</button></td>';
-        memberTableBody.appendChild(tr);
     });
 }
 
-function searchMembers() {
-    var params = new URLSearchParams();
-    if (memberSearchInput.value) params.append('q', memberSearchInput.value);
-    fetch(memberSearchUrl + '?' + params.toString())
-        .then(function(r){ return r.json(); })
-        .then(renderMembers);
+if (numberInput) {
+    numberInput.addEventListener('keyup', function() {
+        var kode = this.value;
+        if (kode.length > 0) {
+            fetch(lookupUrl + '?kode=' + encodeURIComponent(kode))
+                .then(function(r){ return r.json(); })
+                .then(function(m){
+                    if (m) {
+                        document.getElementById('customer-id').value = m.id;
+                        nameInput.value = m.nama_lengkap;
+                        phoneInput.value = m.no_telepon || '';
+                        addressInput.value = m.alamat || '';
+                    } else {
+                        document.getElementById('customer-id').value = '';
+                        nameInput.value = '';
+                        phoneInput.value = '';
+                        addressInput.value = '';
+                    }
+                });
+        } else {
+            document.getElementById('customer-id').value = '';
+            nameInput.value = '';
+            phoneInput.value = '';
+            addressInput.value = '';
+        }
+    });
 }
 
-if (memberSearchBtn && memberSearchInput) {
-    memberSearchBtn.addEventListener('click', searchMembers);
-    memberSearchInput.addEventListener('keyup', function(e){ if (e.key === 'Enter') searchMembers(); });
+if (chooseBtn) {
+    chooseBtn.addEventListener('click', function() {
+        document.getElementById('customer-name').value = nameInput.value;
+        $('#memberModal').modal('hide');
+    });
 }
 
 document.addEventListener('click', function(e) {
-    if (e.target.classList.contains('select-member')) {
-        var id = e.target.getAttribute('data-id');
-        var name = e.target.getAttribute('data-name');
-        document.getElementById('customer-id').value = id;
-        document.getElementById('customer-name').value = name;
-        $('#memberModal').modal('hide');
+    if (e.target.classList.contains('add-to-cart')) {
+        var pid = e.target.getAttribute('data-id');
+        var qtyInput = document.querySelector('input.product-qty[data-id="' + pid + '"]');
+        var qty = qtyInput ? parseInt(qtyInput.value, 10) : 1;
+        if (!qty || qty < 1) { qty = 1; }
+        window.location.href = addUrl + pid + '?qty=' + qty;
     }
 });
-
-var checkoutForm = document.getElementById('checkout-form');
-if (checkoutForm) {
-    checkoutForm.addEventListener('submit', function(e) {
-        var customerId = document.getElementById('customer-id').value;
-        if (!customerId) {
-            e.preventDefault();
-            alert('Pilih customer terlebih dahulu.');
-        }
-    });
-}
 </script>
 <?php $this->load->view('templates/footer'); ?>


### PR DESCRIPTION
## Summary
- validate member phone numbers with new `phone_check` callback and `phone_exists` model helper
- prevent duplicate phone numbers on registration and require phone entry in the form
- localize duplicate email and phone alerts during registration to Bahasa Indonesia
- enforce unique member emails via `email_check` and `email_exists`
- expand cash management options with a new "BON OWNER" category
- streamline POS customer selection with member/non-member option and automatic member lookup
- prefill non-member code in POS customer dialog so member number is never blank

## Testing
- `php -l application/views/cash/add.php`
- `php -l application/views/cash/withdraw.php`
- `php -l application/controllers/Auth.php`
- `php -l application/controllers/Members.php`
- `php -l application/models/User_model.php`
- `php -l application/views/auth/register.php`
- `php -l application/views/pos/index.php`
- `php -l application/controllers/Pos.php`
- `php -l application/models/Member_model.php`
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `composer test:coverage` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aff8d8add08320887202695b98002d