### PR TITLE
Handle non-member customer ID to avoid FK error

### DIFF
--- a/application/controllers/Auth.php
+++ b/application/controllers/Auth.php
@@ -64,7 +64,12 @@ class Auth extends CI_Controller
 
         if ($this->input->method() === 'post') {
             $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
-            $this->form_validation->set_rules('email', 'Email', 'required|valid_email|is_unique[users.email]');
+            $this->form_validation->set_rules('email', 'Email', 'required|valid_email|is_unique[users.email]', [
+                'is_unique' => 'Email sudah digunakan.'
+            ]);
+            $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|is_unique[users.no_telepon]', [
+                'is_unique' => 'No telepon sudah digunakan.'
+            ]);
             $this->form_validation->set_rules('password', 'Password', 'required|min_length[6]');
             $this->form_validation->set_rules('password_confirm', 'Konfirmasi Password', 'required|matches[password]');
 

--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -24,17 +24,23 @@ class Booking extends CI_Controller
         if (!$this->session->userdata('logged_in')) {
             redirect('auth/login');
         }
-        $date = $this->input->get('date');
+        $date   = $this->input->get('date');
         if (!$date) {
             $date = date('Y-m-d');
         }
-        $sort  = $this->input->get('sort') ?: 'jam_mulai';
-        $order = $this->input->get('order') ?: 'asc';
-        $data['date']  = $date;
-        $data['sort']  = $sort;
-        $data['order'] = $order;
-        $data['courts']   = $this->Court_model->get_all();
-        $data['bookings'] = $this->Booking_model->get_by_date($date, $sort, $order);
+        $status = $this->input->get('status');
+        $sort   = $this->input->get('sort') ?: 'jam_mulai';
+        $order  = $this->input->get('order') ?: 'asc';
+        $data['date']   = $date;
+        $data['sort']   = $sort;
+        $data['order']  = $order;
+        $data['status'] = $status;
+        $data['courts'] = $this->Court_model->get_all();
+        if ($status === 'pending') {
+            $data['bookings'] = $this->Booking_model->get_pending($sort, $order);
+        } else {
+            $data['bookings'] = $this->Booking_model->get_by_date($date, $sort, $order);
+        }
         $this->load->view('booking/index', $data);
     }
 
@@ -107,6 +113,12 @@ class Booking extends CI_Controller
             $date     = $this->input->post('tanggal_booking');
             if (strtotime($date) < strtotime(date('Y-m-d'))) {
                 $this->session->set_flashdata('error', 'Tanggal booking tidak boleh sebelum hari ini.');
+                redirect('booking/create');
+                return;
+            }
+            $maxDate = date('Y-m-d', strtotime('+2 months'));
+            if (strtotime($date) > strtotime($maxDate)) {
+                $this->session->set_flashdata('error', 'Tanggal booking tidak boleh lebih dari dua bulan dari hari ini.');
                 redirect('booking/create');
                 return;
             }

--- a/application/controllers/Members.php
+++ b/application/controllers/Members.php
@@ -41,8 +41,8 @@ class Members extends CI_Controller
     {
         $this->authorize();
         $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
-        $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
-        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required');
+        $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check');
+        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|callback_phone_check');
         $this->form_validation->set_rules('password', 'Password', 'required|min_length[6]');
         $this->form_validation->set_rules('alamat', 'Alamat', 'required');
         $this->form_validation->set_rules('kecamatan', 'Kecamatan', 'required');
@@ -84,8 +84,8 @@ class Members extends CI_Controller
     {
         $this->authorize();
         $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
-        $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
-        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required');
+        $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check['.$id.']');
+        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|callback_phone_check['.$id.']');
         $this->form_validation->set_rules('alamat', 'Alamat', 'required');
         $this->form_validation->set_rules('kecamatan', 'Kecamatan', 'required');
         $this->form_validation->set_rules('kota', 'Kota', 'required');
@@ -147,8 +147,8 @@ class Members extends CI_Controller
         $id = $this->session->userdata('id');
 
         $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
-        $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
-        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required');
+        $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check['.$id.']');
+        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|callback_phone_check['.$id.']');
         if ($this->input->post('password')) {
             $this->form_validation->set_rules('password', 'Password', 'min_length[6]');
         }
@@ -185,6 +185,24 @@ class Members extends CI_Controller
 
         $data['member'] = $this->Member_model->get_by_id($id);
         $this->load->view('members/profile', $data);
+    }
+
+    public function email_check($email, $id = NULL)
+    {
+        if ($this->User_model->email_exists($email, $id)) {
+            $this->form_validation->set_message('email_check', 'Email sudah digunakan.');
+            return FALSE;
+        }
+        return TRUE;
+    }
+
+    public function phone_check($no_telepon, $id = NULL)
+    {
+        if ($this->User_model->phone_exists($no_telepon, $id)) {
+            $this->form_validation->set_message('phone_check', 'No telepon sudah digunakan.');
+            return FALSE;
+        }
+        return TRUE;
     }
 }
 ?>

--- a/application/controllers/Pos.php
+++ b/application/controllers/Pos.php
@@ -48,21 +48,20 @@ class Pos extends CI_Controller
         }
         $data['store'] = $this->Store_model->get_current();
         $data['nota'] = $this->Payment_model->get_next_sale_id();
-        $data['members'] = $this->Member_model->get_all();
         $this->load->view('pos/index', $data);
     }
 
     /**
-     * Endpoint AJAX untuk pencarian member.
+     * Endpoint AJAX untuk mengambil detail member berdasarkan kode.
      */
-    public function member_search()
+    public function member_lookup()
     {
         $this->authorize();
-        $keyword = $this->input->get('q');
-        $members = $this->Member_model->search($keyword);
+        $kode = $this->input->get('kode');
+        $member = $this->Member_model->get_by_kode($kode);
         $this->output
             ->set_content_type('application/json')
-            ->set_output(json_encode($members));
+            ->set_output(json_encode($member));
     }
 
     /**
@@ -98,15 +97,22 @@ class Pos extends CI_Controller
         if (!$product) {
             redirect('pos');
         }
+        $qty = (int) $this->input->post('qty');
+        if (!$qty) {
+            $qty = (int) $this->input->get('qty');
+        }
+        if ($qty < 1) {
+            $qty = 1;
+        }
         $cart = $this->session->userdata('cart') ?: [];
         if (isset($cart[$id])) {
-            $cart[$id]['qty'] += 1;
+            $cart[$id]['qty'] += $qty;
         } else {
             $cart[$id] = [
                 'id'         => $product->id,
                 'nama_produk'=> $product->nama_produk,
                 'harga_jual' => $product->harga_jual,
-                'qty'        => 1
+                'qty'        => $qty
             ];
         }
         $this->session->set_userdata('cart', $cart);
@@ -169,10 +175,8 @@ class Pos extends CI_Controller
             return;
         }
         $customerId = $this->input->post('customer_id');
-        if (!$customerId) {
-            $this->session->set_flashdata('error', 'Customer wajib dipilih.');
-            redirect('pos');
-            return;
+        if (!is_numeric($customerId)) {
+            $customerId = null;
         }
         $cart = $this->session->userdata('cart') ?: [];
         if (empty($cart)) {

--- a/application/models/Booking_model.php
+++ b/application/models/Booking_model.php
@@ -30,6 +30,27 @@ class Booking_model extends CI_Model
                         ->result();
     }
 
+    public function get_pending($sort = 'jam_mulai', $order = 'asc')
+    {
+        $allowed = [
+            'id_court'       => 'bookings.id_court',
+            'kode_member'    => 'm.kode_member',
+            'jam_mulai'      => 'bookings.jam_mulai',
+            'jam_selesai'    => 'bookings.jam_selesai',
+            'status_booking' => 'bookings.status_booking',
+            'keterangan'     => 'bookings.keterangan'
+        ];
+        $sort_field = isset($allowed[$sort]) ? $allowed[$sort] : $allowed['jam_mulai'];
+        $order      = strtolower($order) === 'desc' ? 'desc' : 'asc';
+        return $this->db->select('bookings.*, m.kode_member')
+                        ->from($this->table)
+                        ->join('member_data m', 'm.user_id = bookings.id_user', 'left')
+                        ->where('bookings.status_booking', 'pending')
+                        ->order_by($sort_field, $order)
+                        ->get()
+                        ->result();
+    }
+
     public function insert($data)
     {
         return $this->db->insert($this->table, $data);

--- a/application/models/Member_model.php
+++ b/application/models/Member_model.php
@@ -40,6 +40,18 @@ class Member_model extends CI_Model
     }
 
     /**
+     * Ambil satu member berdasarkan kode member.
+     */
+    public function get_by_kode($kode)
+    {
+        $this->db->select('u.id, u.nama_lengkap, u.no_telepon, m.alamat');
+        $this->db->from('users u');
+        $this->db->join('member_data m', 'm.user_id = u.id', 'left');
+        $this->db->where(['m.kode_member' => $kode, 'u.role' => 'pelanggan']);
+        return $this->db->get()->row();
+    }
+
+    /**
      * Ambil satu member berdasarkan ID user.
      */
     public function get_by_id($id)

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -48,6 +48,24 @@ class User_model extends CI_Model
         return $this->db->get($this->table)->result();
     }
 
+    public function email_exists($email, $exclude_id = NULL)
+    {
+        $this->db->where('email', $email);
+        if ($exclude_id !== NULL) {
+            $this->db->where('id !=', $exclude_id);
+        }
+        return $this->db->get($this->table)->num_rows() > 0;
+    }
+
+    public function phone_exists($no_telepon, $exclude_id = NULL)
+    {
+        $this->db->where('no_telepon', $no_telepon);
+        if ($exclude_id !== NULL) {
+            $this->db->where('id !=', $exclude_id);
+        }
+        return $this->db->get($this->table)->num_rows() > 0;
+    }
+
     public function update($id, $data)
     {
         return $this->db->where('id', $id)->update($this->table, $data);

--- a/application/views/auth/register.php
+++ b/application/views/auth/register.php
@@ -17,7 +17,7 @@
     </div>
     <div class="form-group">
         <label for="no_telepon">No. Telepon</label>
-        <input type="text" class="form-control" id="no_telepon" name="no_telepon" value="<?php echo set_value('no_telepon'); ?>">
+        <input type="text" class="form-control" id="no_telepon" name="no_telepon" value="<?php echo set_value('no_telepon'); ?>" required>
     </div>
     <div class="form-group">
         <label for="password">Password</label>

--- a/application/views/booking/create.php
+++ b/application/views/booking/create.php
@@ -18,7 +18,7 @@
     </div>
     <div class="form-group">
         <label for="tanggal_booking">Tanggal</label>
-        <input type="date" name="tanggal_booking" id="tanggal_booking" class="form-control" value="<?php echo set_value('tanggal_booking', date('Y-m-d')); ?>" min="<?php echo date('Y-m-d'); ?>" required>
+        <input type="date" name="tanggal_booking" id="tanggal_booking" class="form-control" value="<?php echo set_value('tanggal_booking', date('Y-m-d')); ?>" min="<?php echo date('Y-m-d'); ?>" max="<?php echo date('Y-m-d', strtotime('+2 months')); ?>" required>
     </div>
     <div class="form-group">
         <label for="jam_mulai">Jam Mulai</label>

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -1,11 +1,15 @@
 <?php $this->load->view('templates/header'); ?>
 <?php $role  = $this->session->userdata('role'); ?>
-<?php $sort  = isset($sort) ? $sort : 'jam_mulai'; ?>
-<?php $order = isset($order) ? $order : 'asc'; ?>
+<?php $sort   = isset($sort) ? $sort : 'jam_mulai'; ?>
+<?php $order  = isset($order) ? $order : 'asc'; ?>
+<?php $status = isset($status) ? $status : ''; ?>
 <?php
-function booking_sort_url($field, $date, $sort, $order)
+function booking_sort_url($field, $date, $status, $sort, $order)
 {
     $next = ($sort === $field && $order === 'asc') ? 'desc' : 'asc';
+    if ($status === 'pending') {
+        return site_url('booking') . '?status=pending&sort=' . $field . '&order=' . $next;
+    }
     return site_url('booking') . '?date=' . urlencode($date) . '&sort=' . $field . '&order=' . $next;
 }
 ?>
@@ -13,20 +17,26 @@ function booking_sort_url($field, $date, $sort, $order)
 <form method="get" class="form-inline mb-3">
     <label for="date" class="mr-2">Tanggal:</label>
     <input type="date" id="date" name="date" class="form-control mr-2" value="<?php echo htmlspecialchars($date); ?>">
+    <label for="status" class="mr-2">Status:</label>
+    <select id="status" name="status" class="form-control mr-2">
+        <option value="">Semua</option>
+        <option value="pending" <?php echo isset($status) && $status === 'pending' ? 'selected' : ''; ?>>Pending</option>
+    </select>
     <button type="submit" class="btn btn-primary">Lihat</button>
     <a href="<?php echo site_url('booking/create'); ?>" class="btn btn-success ml-2">Booking Baru</a>
 </form>
+<input type="text" id="search" class="form-control mb-3" placeholder="Cari booking...">
 
 <?php if (!empty($bookings)): ?>
-    <table class="table table-bordered">
+    <table class="table table-bordered" id="booking-table">
         <thead>
             <tr>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('id_court', $date, $sort, $order)); ?>">Lapangan</a></th>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('kode_member', $date, $sort, $order)); ?>">Kode Member</a></th>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('jam_mulai', $date, $sort, $order)); ?>">Jam Mulai</a></th>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('jam_selesai', $date, $sort, $order)); ?>">Jam Selesai</a></th>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('status_booking', $date, $sort, $order)); ?>">Status</a></th>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('keterangan', $date, $sort, $order)); ?>">Keterangan</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('id_court', $date, $status, $sort, $order)); ?>">Lapangan</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('kode_member', $date, $status, $sort, $order)); ?>">Kode Member</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('jam_mulai', $date, $status, $sort, $order)); ?>">Jam Mulai</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('jam_selesai', $date, $status, $sort, $order)); ?>">Jam Selesai</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('status_booking', $date, $status, $sort, $order)); ?>">Status</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('keterangan', $date, $status, $sort, $order)); ?>">Keterangan</a></th>
                 <?php if ($role === 'kasir'): ?>
                     <th>Aksi</th>
                 <?php endif; ?>
@@ -69,4 +79,16 @@ function booking_sort_url($field, $date, $sort, $order)
 <?php else: ?>
     <p>Tidak ada booking pada tanggal ini.</p>
 <?php endif; ?>
+<script>
+document.getElementById('status').addEventListener('change', function() {
+    document.getElementById('date').disabled = this.value === 'pending';
+});
+document.getElementById('status').dispatchEvent(new Event('change'));
+document.getElementById('search').addEventListener('keyup', function() {
+    var filter = this.value.toLowerCase();
+    document.querySelectorAll('#booking-table tbody tr').forEach(function(row) {
+        row.style.display = row.textContent.toLowerCase().includes(filter) ? '' : 'none';
+    });
+});
+</script>
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/cash/add.php
+++ b/application/views/cash/add.php
@@ -14,6 +14,7 @@
         <select name="category" id="category" class="form-control">
             <option value="BON OPERASIONAL">BON OPERASIONAL</option>
             <option value="BON TRANSFER BANK">BON TRANSFER BANK</option>
+            <option value="BON OWNER">BON OWNER</option>
             <option value="DEBIT CREDIT CARD">DEBIT CREDIT CARD</option>
             <option value="MODAL">MODAL</option>
         </select>

--- a/application/views/cash/withdraw.php
+++ b/application/views/cash/withdraw.php
@@ -14,6 +14,7 @@
         <select name="category" id="category" class="form-control">
             <option value="BON OPERASIONAL">BON OPERASIONAL</option>
             <option value="BON TRANSFER BANK">BON TRANSFER BANK</option>
+            <option value="BON OWNER">BON OWNER</option>
             <option value="DEBIT CREDIT CARD">DEBIT CREDIT CARD</option>
             <option value="MODAL">MODAL</option>
         </select>

--- a/application/views/pos/transactions.php
+++ b/application/views/pos/transactions.php
@@ -23,7 +23,7 @@
             <?php foreach ($sales as $s): ?>
                 <tr>
                     <td><?php echo htmlspecialchars($s->nomor_nota); ?></td>
-                    <td><?php echo htmlspecialchars($s->customer_name); ?></td>
+                    <td><?php echo htmlspecialchars($s->customer_name ?: 'non member'); ?></td>
                     <td>Rp <?php echo number_format($s->total_belanja, 0, ',', '.'); ?></td>
                     <td><?php echo htmlspecialchars($s->tanggal_transaksi); ?></td>
                 </tr>


### PR DESCRIPTION
## Summary
- ignore non-numeric customer ids during checkout so non-member transactions save without foreign key errors
- clear hidden customer id when selecting Non Member in the POS dialog
- show "non member" in POS transaction list when a sale has no linked customer
- limit booking date selection to at most two months ahead of today
- add live search and pending-status filter to booking schedule to list all pending bookings without date restriction

## Testing
- `php -l application/controllers/Booking.php`
- `php -l application/views/booking/create.php`
- `composer install` (fails: CONNECT tunnel failed, response 403)
- `composer test:coverage` (fails: phpunit: not found)


------
https://chatgpt.com/codex/tasks/task_e_68aff8d8add08320887202695b98002d