### PR TITLE
feat: show courts on customer dashboard

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -13,6 +13,7 @@ class Dashboard extends CI_Controller
         parent::__construct();
         $this->load->library('session');
         $this->load->helper(['url']);
+        $this->load->model('Court_model');
     }
 
     /**
@@ -24,8 +25,9 @@ class Dashboard extends CI_Controller
             redirect('auth/login');
         }
 
-        $role = $this->session->userdata('role');
-        $view = '';
+        $role  = $this->session->userdata('role');
+        $data  = [];
+        $view  = '';
         switch ($role) {
             case 'kasir':
                 $view = 'dashboard/kasir';
@@ -37,9 +39,10 @@ class Dashboard extends CI_Controller
                 $view = 'dashboard/owner';
                 break;
             default:
-                $view = 'dashboard/customer';
+                $view             = 'dashboard/customer';
+                $data['courts']   = $this->Court_model->get_all();
                 break;
         }
-        $this->load->view($view);
+        $this->load->view($view, $data);
     }
 }

--- a/application/views/dashboard/customer.php
+++ b/application/views/dashboard/customer.php
@@ -1,4 +1,24 @@
 <?php $this->load->view('templates/header'); ?>
 <h2>Dashboard Pelanggan</h2>
 <p>Selamat datang di PadelPro. Gunakan menu untuk melakukan booking lapangan.</p>
+
+<div class="row">
+    <?php if (!empty($courts)): ?>
+        <?php foreach ($courts as $court): ?>
+            <div class="col-md-4 mb-4">
+                <div class="card h-100">
+                    <img src="<?php echo base_url('uploads/courts/' . $court->gambar); ?>" class="card-img-top" alt="Gambar Lapangan">
+                    <div class="card-body d-flex flex-column">
+                        <h5 class="card-title"><?php echo htmlspecialchars($court->nama_lapangan); ?></h5>
+                        <p class="card-text mb-4">Harga per jam: <?php echo number_format($court->harga_per_jam, 0, ',', '.'); ?></p>
+                        <a href="<?php echo site_url('booking'); ?>" class="btn btn-primary mt-auto">Lihat Jadwal Booking</a>
+                    </div>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    <?php else: ?>
+        <div class="col-12"><p>Tidak ada lapangan tersedia.</p></div>
+    <?php endif; ?>
+</div>
+
 <?php $this->load->view('templates/footer'); ?>


### PR DESCRIPTION
## Summary
- show available courts on the customer dashboard
- add booking schedule button below each court card

## Testing
- `php -l application/controllers/Dashboard.php`
- `php -l application/views/dashboard/customer.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b16708d5d483209b10c2a712f50c18