### PR TITLE
feat: add member selection to cashier booking form

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -149,8 +149,23 @@ class Booking extends CI_Controller
             }
             $court = $this->Court_model->get_by_id($id_court);
             $total = $court->harga_per_jam * $durasi;
+            $id_user = $this->session->userdata('id');
+            if ($this->session->userdata('role') === 'kasir') {
+                $type = $this->input->post('customer_type');
+                if ($type === 'member') {
+                    $cust = (int) $this->input->post('customer_id');
+                    if (!$cust) {
+                        $this->session->set_flashdata('error', 'Nomor member tidak valid.');
+                        redirect('booking/create');
+                        return;
+                    }
+                    $id_user = $cust;
+                } else {
+                    $id_user = 0;
+                }
+            }
             $data = [
-                'id_user'          => $this->session->userdata('id'),
+                'id_user'          => $id_user,
                 'id_court'         => $id_court,
                 'tanggal_booking'  => $date,
                 'jam_mulai'        => $start,
@@ -160,11 +175,11 @@ class Booking extends CI_Controller
                 'status_booking'   => 'pending',
                 'status_pembayaran'=> 'belum_bayar'
             ];
-        $this->Booking_model->insert($data);
-        $this->session->set_flashdata('success', 'Booking berhasil disimpan, silakan lakukan pembayaran.');
-        redirect('booking');
-        return;
-    }
+            $this->Booking_model->insert($data);
+            $this->session->set_flashdata('success', 'Booking berhasil disimpan, silakan lakukan pembayaran.');
+            redirect('booking');
+            return;
+        }
         $this->create();
     }
 

--- a/application/models/Booking_model.php
+++ b/application/models/Booking_model.php
@@ -94,12 +94,15 @@ class Booking_model extends CI_Model
      */
     public function get_cancelled($date = null)
     {
-        $this->db->where('status_booking', 'batal');
+        $this->db->select('bookings.*, m.kode_member');
+        $this->db->from($this->table);
+        $this->db->join('member_data m', 'm.user_id = bookings.id_user', 'left');
+        $this->db->where('bookings.status_booking', 'batal');
         if (!empty($date)) {
-            $this->db->where('tanggal_booking', $date);
+            $this->db->where('bookings.tanggal_booking', $date);
         }
-        return $this->db->order_by('tanggal_booking', 'desc')
-                        ->get($this->table)
+        return $this->db->order_by('bookings.tanggal_booking', 'desc')
+                        ->get()
                         ->result();
     }
 

--- a/application/views/booking/cancelled.php
+++ b/application/views/booking/cancelled.php
@@ -11,7 +11,7 @@
         <thead>
             <tr>
                 <th>Lapangan</th>
-                <th>Pelanggan</th>
+                <th>Kode Member</th>
                 <th>Jam Mulai</th>
                 <th>Jam Selesai</th>
                 <th>Keterangan</th>
@@ -21,7 +21,7 @@
         <?php foreach ($bookings as $b): ?>
             <tr>
                 <td><?php echo htmlspecialchars($b->id_court); ?></td>
-                <td><?php echo htmlspecialchars($b->id_user); ?></td>
+                <td><?php echo htmlspecialchars(!empty($b->kode_member) ? $b->kode_member : 'non member'); ?></td>
                 <td><?php echo htmlspecialchars($b->jam_mulai); ?></td>
                 <td><?php echo htmlspecialchars($b->jam_selesai); ?></td>
                 <td><?php echo htmlspecialchars($b->keterangan); ?></td>

--- a/application/views/booking/create.php
+++ b/application/views/booking/create.php
@@ -7,6 +7,32 @@
 <?php echo validation_errors('<div class="alert alert-danger">', '</div>'); ?>
 <form method="post" action="<?php echo site_url('booking/store'); ?>">
     <input type="hidden" name="device_date" id="device_date">
+    <?php if ($this->session->userdata('role') === 'kasir'): ?>
+    <input type="hidden" name="customer_id" id="customer-id">
+    <div class="form-group">
+        <label for="customer-type">Tipe Customer</label>
+        <select name="customer_type" id="customer-type" class="form-control">
+            <option value="member">Member</option>
+            <option value="non">Non Member</option>
+        </select>
+    </div>
+    <div class="form-group">
+        <label for="member-number">Nomor Member</label>
+        <input type="text" name="member_number" id="member-number" class="form-control">
+    </div>
+    <div class="form-group">
+        <label for="customer-name">Nama</label>
+        <input type="text" name="customer_name" id="customer-name" class="form-control" readonly>
+    </div>
+    <div class="form-group">
+        <label for="customer-phone">No Telepon</label>
+        <input type="text" name="customer_phone" id="customer-phone" class="form-control" readonly>
+    </div>
+    <div class="form-group">
+        <label for="customer-address">Alamat</label>
+        <textarea name="customer_address" id="customer-address" class="form-control" readonly></textarea>
+    </div>
+    <?php endif; ?>
     <div class="form-group">
         <label for="id_court">Lapangan</label>
         <select name="id_court" id="id_court" class="form-control" required>
@@ -34,5 +60,74 @@
 <script>
 var now = new Date();
 document.getElementById('device_date').value = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
+<?php if ($this->session->userdata('role') === 'kasir'): ?>
+var typeSelect = document.getElementById('customer-type');
+var numberInput = document.getElementById('member-number');
+var nameInput = document.getElementById('customer-name');
+var phoneInput = document.getElementById('customer-phone');
+var addressInput = document.getElementById('customer-address');
+var customerIdInput = document.getElementById('customer-id');
+var lookupUrl = '<?php echo site_url('pos/member_lookup'); ?>';
+if (typeSelect && typeSelect.value === 'non') {
+    numberInput.value = 'non member';
+    numberInput.disabled = true;
+    nameInput.readOnly = false;
+    phoneInput.readOnly = false;
+    addressInput.readOnly = false;
+}
+if (typeSelect) {
+    typeSelect.addEventListener('change', function() {
+        if (this.value === 'member') {
+            numberInput.disabled = false;
+            numberInput.value = '';
+            nameInput.readOnly = true;
+            phoneInput.readOnly = true;
+            addressInput.readOnly = true;
+            nameInput.value = '';
+            phoneInput.value = '';
+            addressInput.value = '';
+            if (customerIdInput) customerIdInput.value = '';
+            numberInput.focus();
+        } else {
+            numberInput.value = 'non member';
+            numberInput.disabled = true;
+            nameInput.readOnly = false;
+            phoneInput.readOnly = false;
+            addressInput.readOnly = false;
+            nameInput.value = '';
+            phoneInput.value = '';
+            addressInput.value = '';
+            if (customerIdInput) customerIdInput.value = '';
+        }
+    });
+}
+if (numberInput) {
+    numberInput.addEventListener('keyup', function() {
+        var kode = this.value;
+        if (kode.length > 0) {
+            fetch(lookupUrl + '?kode=' + encodeURIComponent(kode))
+                .then(function(r){ return r.json(); })
+                .then(function(m){
+                    if (m) {
+                        if (customerIdInput) customerIdInput.value = m.id;
+                        nameInput.value = m.nama_lengkap;
+                        phoneInput.value = m.no_telepon || '';
+                        addressInput.value = m.alamat || '';
+                    } else {
+                        if (customerIdInput) customerIdInput.value = '';
+                        nameInput.value = '';
+                        phoneInput.value = '';
+                        addressInput.value = '';
+                    }
+                });
+        } else {
+            if (customerIdInput) customerIdInput.value = '';
+            nameInput.value = '';
+            phoneInput.value = '';
+            addressInput.value = '';
+        }
+    });
+}
+<?php endif; ?>
 </script>
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -49,7 +49,7 @@ function booking_sort_url($field, $date, $status, $sort, $order)
                 <td><?php echo htmlspecialchars($b->nama_lapangan); ?></td>
                 <td><?php echo htmlspecialchars(date('H:i', strtotime($b->jam_mulai))); ?></td>
                 <td><?php echo htmlspecialchars(date('H:i', strtotime($b->jam_selesai))); ?></td>
-                <td><?php echo htmlspecialchars($b->kode_member); ?></td>
+                <td><?php echo htmlspecialchars(!empty($b->kode_member) ? $b->kode_member : 'non member'); ?></td>
                 <td><?php echo htmlspecialchars($b->status_booking); ?></td>
                 <td><?php echo htmlspecialchars($b->keterangan); ?></td>
                 <?php if ($role === 'kasir'): ?>


### PR DESCRIPTION
## Summary
- capture selected member or non-member when cashiers save bookings
- show member number or 'non member' in booking schedule
- display member codes for cancelled bookings

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php -l application/controllers/Booking.php`
- `php -l application/views/booking/index.php`
- `php -l application/models/Booking_model.php`
- `php -l application/views/booking/cancelled.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4d136d5648320bb6458ee5c1e7759