### PR TITLE
Fix receipt duration display in minutes

### DIFF
--- a/application/models/Booking_model.php
+++ b/application/models/Booking_model.php
@@ -72,7 +72,21 @@ class Booking_model extends CI_Model
 
     public function insert($data)
     {
-        return $this->db->insert($this->table, $data);
+        $this->db->insert($this->table, $data);
+        return $this->db->insert_id();
+    }
+
+    /**
+     * Ambil satu booking beserta nama lapangan.
+     */
+    public function find_with_court($id)
+    {
+        return $this->db->select('b.*, c.nama_lapangan')
+                        ->from($this->table . ' b')
+                        ->join('courts c', 'c.id = b.id_court', 'left')
+                        ->where('b.id', $id)
+                        ->get()
+                        ->row();
     }
 
     /**
@@ -94,12 +108,15 @@ class Booking_model extends CI_Model
      */
     public function get_cancelled($date = null)
     {
-        $this->db->where('status_booking', 'batal');
+        $this->db->select('bookings.*, m.kode_member');
+        $this->db->from($this->table);
+        $this->db->join('member_data m', 'm.user_id = bookings.id_user', 'left');
+        $this->db->where('bookings.status_booking', 'batal');
         if (!empty($date)) {
-            $this->db->where('tanggal_booking', $date);
+            $this->db->where('bookings.tanggal_booking', $date);
         }
-        return $this->db->order_by('tanggal_booking', 'desc')
-                        ->get($this->table)
+        return $this->db->order_by('bookings.tanggal_booking', 'desc')
+                        ->get()
                         ->result();
     }
 

--- a/application/views/booking/cancelled.php
+++ b/application/views/booking/cancelled.php
@@ -11,7 +11,7 @@
         <thead>
             <tr>
                 <th>Lapangan</th>
-                <th>Pelanggan</th>
+                <th>Kode Member</th>
                 <th>Jam Mulai</th>
                 <th>Jam Selesai</th>
                 <th>Keterangan</th>
@@ -21,7 +21,7 @@
         <?php foreach ($bookings as $b): ?>
             <tr>
                 <td><?php echo htmlspecialchars($b->id_court); ?></td>
-                <td><?php echo htmlspecialchars($b->id_user); ?></td>
+                <td><?php echo htmlspecialchars(!empty($b->kode_member) ? $b->kode_member : 'non member'); ?></td>
                 <td><?php echo htmlspecialchars($b->jam_mulai); ?></td>
                 <td><?php echo htmlspecialchars($b->jam_selesai); ?></td>
                 <td><?php echo htmlspecialchars($b->keterangan); ?></td>

--- a/application/views/booking/create.php
+++ b/application/views/booking/create.php
@@ -7,12 +7,38 @@
 <?php echo validation_errors('<div class="alert alert-danger">', '</div>'); ?>
 <form method="post" action="<?php echo site_url('booking/store'); ?>">
     <input type="hidden" name="device_date" id="device_date">
+    <?php if ($this->session->userdata('role') === 'kasir'): ?>
+    <input type="hidden" name="customer_id" id="customer-id">
+    <div class="form-group">
+        <label for="customer-type">Tipe Customer</label>
+        <select name="customer_type" id="customer-type" class="form-control">
+            <option value="member">Member</option>
+            <option value="non">Non Member</option>
+        </select>
+    </div>
+    <div class="form-group">
+        <label for="member-number">Nomor Member</label>
+        <input type="text" name="member_number" id="member-number" class="form-control">
+    </div>
+    <div class="form-group">
+        <label for="customer-name">Nama</label>
+        <input type="text" name="customer_name" id="customer-name" class="form-control" readonly>
+    </div>
+    <div class="form-group">
+        <label for="customer-phone">No Telepon</label>
+        <input type="text" name="customer_phone" id="customer-phone" class="form-control" readonly>
+    </div>
+    <div class="form-group">
+        <label for="customer-address">Alamat</label>
+        <textarea name="customer_address" id="customer-address" class="form-control" readonly></textarea>
+    </div>
+    <?php endif; ?>
     <div class="form-group">
         <label for="id_court">Lapangan</label>
         <select name="id_court" id="id_court" class="form-control" required>
             <option value="">-- Pilih Lapangan --</option>
             <?php foreach ($courts as $court): ?>
-                <option value="<?php echo $court->id; ?>" <?php echo set_select('id_court', $court->id, isset($selected_court) && (int)$selected_court === (int)$court->id); ?>><?php echo htmlspecialchars($court->nama_lapangan); ?></option>
+                <option value="<?php echo $court->id; ?>" data-price="<?php echo $court->harga_per_jam; ?>" <?php echo set_select('id_court', $court->id, isset($selected_court) && (int)$selected_court === (int)$court->id); ?>><?php echo htmlspecialchars($court->nama_lapangan); ?></option>
             <?php endforeach; ?>
         </select>
     </div>
@@ -28,11 +54,146 @@
         <label for="jam_selesai">Jam Selesai</label>
         <input type="time" name="jam_selesai" id="jam_selesai" class="form-control" value="<?php echo set_value('jam_selesai', isset($selected_end) ? $selected_end : ''); ?>" required>
     </div>
+    <?php if ($this->session->userdata('role') === 'kasir'): ?>
+    <div class="form-group">
+        <label for="harga-booking">Harga Booking</label>
+        <input type="text" id="harga-booking" class="form-control" readonly>
+    </div>
+    <div class="form-group">
+        <label for="diskon-persen">Diskon (%)</label>
+        <input type="number" name="diskon_persen" id="diskon-persen" class="form-control" min="0" max="100" step="0.01">
+    </div>
+    <div class="form-group">
+        <label for="diskon-rupiah">Diskon (Rp)</label>
+        <input type="number" name="diskon_rupiah" id="diskon-rupiah" class="form-control" min="0" step="100">
+    </div>
+    <div class="form-group">
+        <label for="total-bayar">Total Harga</label>
+        <input type="text" id="total-bayar" class="form-control" readonly>
+    </div>
+    <?php endif; ?>
     <button type="submit" class="btn btn-primary">Simpan Booking</button>
     <a href="<?php echo site_url('booking'); ?>" class="btn btn-secondary">Batal</a>
 </form>
 <script>
 var now = new Date();
 document.getElementById('device_date').value = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
+<?php if ($this->session->userdata('role') === 'kasir'): ?>
+var typeSelect = document.getElementById('customer-type');
+var numberInput = document.getElementById('member-number');
+var nameInput = document.getElementById('customer-name');
+var phoneInput = document.getElementById('customer-phone');
+var addressInput = document.getElementById('customer-address');
+var customerIdInput = document.getElementById('customer-id');
+var lookupUrl = '<?php echo site_url('pos/member_lookup'); ?>';
+if (typeSelect && typeSelect.value === 'non') {
+    numberInput.value = 'non member';
+    numberInput.disabled = true;
+    nameInput.readOnly = false;
+    phoneInput.readOnly = false;
+    addressInput.readOnly = false;
+}
+if (typeSelect) {
+    typeSelect.addEventListener('change', function() {
+        if (this.value === 'member') {
+            numberInput.disabled = false;
+            numberInput.value = '';
+            nameInput.readOnly = true;
+            phoneInput.readOnly = true;
+            addressInput.readOnly = true;
+            nameInput.value = '';
+            phoneInput.value = '';
+            addressInput.value = '';
+            if (customerIdInput) customerIdInput.value = '';
+            numberInput.focus();
+        } else {
+            numberInput.value = 'non member';
+            numberInput.disabled = true;
+            nameInput.readOnly = false;
+            phoneInput.readOnly = false;
+            addressInput.readOnly = false;
+            nameInput.value = '';
+            phoneInput.value = '';
+            addressInput.value = '';
+            if (customerIdInput) customerIdInput.value = '';
+        }
+    });
+}
+if (numberInput) {
+    numberInput.addEventListener('keyup', function() {
+        var kode = this.value;
+        if (kode.length > 0) {
+            fetch(lookupUrl + '?kode=' + encodeURIComponent(kode))
+                .then(function(r){ return r.json(); })
+                .then(function(m){
+                    if (m) {
+                        if (customerIdInput) customerIdInput.value = m.id;
+                        nameInput.value = m.nama_lengkap;
+                        phoneInput.value = m.no_telepon || '';
+                        addressInput.value = m.alamat || '';
+                    } else {
+                        if (customerIdInput) customerIdInput.value = '';
+                        nameInput.value = '';
+                        phoneInput.value = '';
+                        addressInput.value = '';
+                    }
+                });
+        } else {
+            if (customerIdInput) customerIdInput.value = '';
+            nameInput.value = '';
+            phoneInput.value = '';
+            addressInput.value = '';
+        }
+    });
+}
+var courtSelect = document.getElementById('id_court');
+var startInput = document.getElementById('jam_mulai');
+var endInput = document.getElementById('jam_selesai');
+var hargaBookingInput = document.getElementById('harga-booking');
+var diskonPersenInput = document.getElementById('diskon-persen');
+var diskonRupiahInput = document.getElementById('diskon-rupiah');
+var totalBayarInput = document.getElementById('total-bayar');
+function timeToMinutes(t){var p=t.split(':');return p.length===2?parseInt(p[0],10)*60+parseInt(p[1],10):0;}
+function updatePayment(e){
+    var pricePerHour = 0;
+    if (courtSelect) {
+        var opt = courtSelect.options[courtSelect.selectedIndex];
+        pricePerHour = parseFloat(opt.getAttribute('data-price')) || 0;
+    }
+    var start = startInput.value;
+    var end = endInput.value;
+var durasi = 0;
+if (start && end) {
+    durasi = timeToMinutes(end) - timeToMinutes(start);
+    if (durasi < 0) durasi = 0;
+}
+var harga = pricePerHour * (durasi / 60);
+    if (hargaBookingInput) hargaBookingInput.value = harga ? harga.toFixed(0) : '';
+    var discPercent = parseFloat(diskonPersenInput.value) || 0;
+    var discAmount = parseFloat(diskonRupiahInput.value) || 0;
+    if (e && e.target === diskonPersenInput) {
+        discAmount = harga * (discPercent / 100);
+        diskonRupiahInput.value = discAmount ? discAmount.toFixed(0) : '';
+    } else if (e && e.target === diskonRupiahInput) {
+        discPercent = harga ? (discAmount / harga) * 100 : 0;
+        diskonPersenInput.value = discPercent ? discPercent.toFixed(2) : '';
+    } else {
+        if (discPercent) {
+            discAmount = harga * (discPercent / 100);
+            diskonRupiahInput.value = discAmount ? discAmount.toFixed(0) : '';
+        } else if (discAmount) {
+            discPercent = harga ? (discAmount / harga) * 100 : 0;
+            diskonPersenInput.value = discPercent ? discPercent.toFixed(2) : '';
+        }
+    }
+    var total = harga - discAmount;
+    if (totalBayarInput) totalBayarInput.value = total > 0 ? total.toFixed(0) : '0';
+}
+if (courtSelect) courtSelect.addEventListener('change', updatePayment);
+if (startInput) startInput.addEventListener('change', updatePayment);
+if (endInput) endInput.addEventListener('change', updatePayment);
+if (diskonPersenInput) diskonPersenInput.addEventListener('input', updatePayment);
+if (diskonRupiahInput) diskonRupiahInput.addEventListener('input', updatePayment);
+<?php endif; ?>
 </script>
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -40,6 +40,10 @@ function booking_sort_url($field, $date, $status, $sort, $order)
                 <th><a href="<?php echo htmlspecialchars(booking_sort_url('kode_member', $date, $status, $sort, $order)); ?>">Kode Member</a></th>
                 <th><a href="<?php echo htmlspecialchars(booking_sort_url('status_booking', $date, $status, $sort, $order)); ?>">Status</a></th>
                 <th><a href="<?php echo htmlspecialchars(booking_sort_url('keterangan', $date, $status, $sort, $order)); ?>">Keterangan</a></th>
+                <?php if ($role === 'kasir'): ?>
+                    <th>Nota</th>
+                    <th>Aksi</th>
+                <?php endif; ?>
             </tr>
         </thead>
         <tbody>
@@ -49,12 +53,14 @@ function booking_sort_url($field, $date, $status, $sort, $order)
                 <td><?php echo htmlspecialchars($b->nama_lapangan); ?></td>
                 <td><?php echo htmlspecialchars(date('H:i', strtotime($b->jam_mulai))); ?></td>
                 <td><?php echo htmlspecialchars(date('H:i', strtotime($b->jam_selesai))); ?></td>
-                <td><?php echo htmlspecialchars($b->kode_member); ?></td>
+                <td><?php echo htmlspecialchars(!empty($b->kode_member) ? $b->kode_member : 'non member'); ?></td>
                 <td><?php echo htmlspecialchars($b->status_booking); ?></td>
                 <td><?php echo htmlspecialchars($b->keterangan); ?></td>
                 <?php if ($role === 'kasir'): ?>
-                <td>
-                    
+                    <td>
+                        <a href="<?php echo site_url('booking/print_receipt/' . $b->id); ?>" class="btn btn-sm btn-secondary">Reprint</a>
+                    </td>
+                    <td>
                         <?php if ($b->status_booking === 'pending'): ?>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
                                 <input type="hidden" name="status" value="confirmed">
@@ -72,8 +78,8 @@ function booking_sort_url($field, $date, $status, $sort, $order)
                                 <button type="submit" name="status" value="batal" class="btn btn-sm btn-danger">Batal</button>
                             </form>
                         <?php endif; ?>
-                    <?php endif; ?>
-                </td>
+                    </td>
+                <?php endif; ?>
             </tr>
         <?php endforeach; ?>
         </tbody>

--- a/database.sql
+++ b/database.sql
@@ -36,6 +36,8 @@ CREATE TABLE `bookings` (
   `jam_mulai` time NOT NULL,
   `jam_selesai` time NOT NULL,
   `durasi` int(11) NOT NULL,
+  `harga_booking` decimal(10,2) NOT NULL,
+  `diskon` decimal(10,2) NOT NULL,
   `total_harga` decimal(10,2) NOT NULL,
   `status_booking` enum('pending','confirmed','batal','selesai') DEFAULT 'pending',
   `keterangan` text,
@@ -47,13 +49,13 @@ CREATE TABLE `bookings` (
 -- Dumping data for table `bookings`
 --
 
-INSERT INTO `bookings` (`id`, `id_user`, `id_court`, `tanggal_booking`, `jam_mulai`, `jam_selesai`, `durasi`, `total_harga`, `status_booking`, `keterangan`, `status_pembayaran`, `created_at`) VALUES
-(1, 1, 1, '2025-08-25', '13:00:00', '14:00:00', 1, '300000.00', 'pending', NULL, 'belum_bayar', '2025-08-26 01:59:44'),
-(2, 1, 1, '2025-08-27', '13:00:00', '14:00:00', 1, '300000.00', 'pending', NULL, 'belum_bayar', '2025-08-26 02:00:29'),
-(3, 3, 2, '2025-08-25', '13:00:00', '14:00:00', 1, '300000.00', 'pending', NULL, 'belum_bayar', '2025-08-25 02:27:04'),
-(4, 3, 3, '2025-08-25', '13:00:00', '14:00:00', 1, '300000.00', 'batal', '', 'belum_bayar', '2025-08-25 02:33:16'),
-(5, 1, 1, '2025-08-25', '14:00:00', '15:00:00', 1, '300000.00', 'batal', '', 'belum_bayar', '2025-08-26 02:38:42'),
-(6, 1, 2, '2025-08-24', '13:00:00', '14:00:00', 1, '300000.00', 'pending', NULL, 'belum_bayar', '2025-08-26 02:39:50');
+INSERT INTO `bookings` (`id`, `id_user`, `id_court`, `tanggal_booking`, `jam_mulai`, `jam_selesai`, `durasi`, `harga_booking`, `diskon`, `total_harga`, `status_booking`, `keterangan`, `status_pembayaran`, `created_at`) VALUES
+(1, 1, 1, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, 'belum_bayar', '2025-08-26 01:59:44'),
+(2, 1, 1, '2025-08-27', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, 'belum_bayar', '2025-08-26 02:00:29'),
+(3, 3, 2, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, 'belum_bayar', '2025-08-25 02:27:04'),
+(4, 3, 3, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'batal', '', 'belum_bayar', '2025-08-25 02:33:16'),
+(5, 1, 1, '2025-08-25', '14:00:00', '15:00:00', 60, '300000.00', '0.00', '300000.00', 'batal', '', 'belum_bayar', '2025-08-26 02:38:42'),
+(6, 1, 2, '2025-08-24', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, 'belum_bayar', '2025-08-26 02:39:50');
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- compute booking duration in minutes when printing receipts so hour-long rentals show 60 minutes

## Testing
- `composer install --no-interaction --no-progress` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php -l application/controllers/Booking.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4d136d5648320bb6458ee5c1e7759