### PR TITLE
Use print icon for booking receipt

### DIFF
--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -80,7 +80,7 @@ function booking_sort_url($field, $date, $status, $sort, $order)
                     </td>
                 <?php endif; ?>
                 <td>
-                        <a href="<?php echo site_url('booking/print_receipt/' . $b->id); ?>" class="btn btn-sm btn-secondary">Reprint</a>
+                        <a href="<?php echo site_url('booking/print_receipt/' . $b->id); ?>" class="btn btn-sm btn-secondary" title="Print nota" aria-label="Print nota"><i class="fas fa-print"></i></a>
                     </td>
             </tr>
         <?php endforeach; ?>

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -12,6 +12,8 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
     <title>PadelPro</title>
     <!-- Bootstrap CSS via CDN -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- Font Awesome for icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-light bg-light">


### PR DESCRIPTION
## Summary
- replace text-based reprint button in booking schedule with printer icon
- load Font Awesome in header for icon support

## Testing
- `php -l application/views/booking/index.php`
- `php -l application/views/templates/header.php`
- `composer test:coverage` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b60ac93c188320a74f2683f939fdc1