### PR TITLE
Use printer icons, add live product search, add Perlengkapan Padel category, and export product list to Excel

### DIFF
--- a/application/controllers/Products.php
+++ b/application/controllers/Products.php
@@ -6,7 +6,6 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  */
 class Products extends CI_Controller
 {
-    private $categories = ['makanan','snack','cofee','non cofee','tea'];
     public function __construct()
     {
         parent::__construct();
@@ -29,14 +28,38 @@ class Products extends CI_Controller
     public function index()
     {
         $this->authorize();
-        $data['products'] = $this->Product_model->get_all();
+        $start_date = $this->input->get('start_date');
+        $end_date   = $this->input->get('end_date');
+        $data['start_date'] = $start_date;
+        $data['end_date']   = $end_date;
+        $data['products'] = $this->Product_model->get_all($start_date, $end_date);
         $this->load->view('products/index', $data);
+    }
+
+    public function export_excel()
+    {
+        $this->authorize();
+        $start_date = $this->input->get('start_date');
+        $end_date   = $this->input->get('end_date');
+        $products   = $this->Product_model->get_all($start_date, $end_date);
+
+        header('Content-Type: application/vnd.ms-excel');
+        header('Content-Disposition: attachment; filename="daftar_produk.xls"');
+
+        $data = [
+            'title'      => 'Daftar Produk',
+            'start_date' => $start_date,
+            'end_date'   => $end_date,
+            'products'   => $products
+        ];
+
+        $this->load->view('products/export_excel', $data);
     }
 
     public function create()
     {
         $this->authorize();
-        $data['categories'] = $this->categories;
+        $data['categories'] = $this->Product_model->get_categories();
         $this->load->view('products/create', $data);
     }
 
@@ -46,7 +69,8 @@ class Products extends CI_Controller
         $this->form_validation->set_rules('nama_produk', 'Nama Produk', 'required');
         $this->form_validation->set_rules('harga_jual', 'Harga Jual', 'required|numeric');
         $this->form_validation->set_rules('stok', 'Stok', 'required|integer');
-        $this->form_validation->set_rules('kategori', 'Kategori', 'required|in_list['.implode(',', $this->categories).']');
+        $category_list = $this->Product_model->get_categories();
+        $this->form_validation->set_rules('kategori', 'Kategori', 'required|in_list['.implode(',', $category_list).']');
         if ($this->form_validation->run() === TRUE) {
             $data = [
                 'nama_produk' => $this->input->post('nama_produk', TRUE),
@@ -66,7 +90,7 @@ class Products extends CI_Controller
     {
         $this->authorize();
         $data['product'] = $this->Product_model->get_by_id($id);
-        $data['categories'] = $this->categories;
+        $data['categories'] = $this->Product_model->get_categories();
         $this->load->view('products/edit', $data);
     }
 
@@ -76,7 +100,8 @@ class Products extends CI_Controller
         $this->form_validation->set_rules('nama_produk', 'Nama Produk', 'required');
         $this->form_validation->set_rules('harga_jual', 'Harga Jual', 'required|numeric');
         $this->form_validation->set_rules('stok', 'Stok', 'required|integer');
-        $this->form_validation->set_rules('kategori', 'Kategori', 'required|in_list['.implode(',', $this->categories).']');
+        $category_list = $this->Product_model->get_categories();
+        $this->form_validation->set_rules('kategori', 'Kategori', 'required|in_list['.implode(',', $category_list).']');
         if ($this->form_validation->run() === TRUE) {
             $data = [
                 'nama_produk' => $this->input->post('nama_produk', TRUE),

--- a/application/models/Product_model.php
+++ b/application/models/Product_model.php
@@ -7,17 +7,31 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 class Product_model extends CI_Model
 {
     protected $table = 'products';
+    /**
+     * Daftar kategori yang digunakan di seluruh aplikasi.
+     *
+     * Menggunakan satu sumber kebenaran agar halaman lain
+     * (seperti POS) dapat menampilkan semua kategori meski
+     * belum ada produk di dalamnya.
+     */
+    public $categories = ['makanan','snack','cofee','non cofee','tea','perlengkapan padel'];
 
     /**
-     * Ambil semua kategori produk yang tersedia.
+     * Ambil semua kategori yang diizinkan.
      */
     public function get_categories()
     {
-        return $this->db->select('kategori')->distinct()->order_by('kategori')->get($this->table)->result();
+        return $this->categories;
     }
 
-    public function get_all()
+    public function get_all($start_date = null, $end_date = null)
     {
+        if ($start_date) {
+            $this->db->where('DATE(created_at) >=', $start_date);
+        }
+        if ($end_date) {
+            $this->db->where('DATE(created_at) <=', $end_date);
+        }
         return $this->db->get($this->table)->result();
     }
 

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -80,7 +80,7 @@ function booking_sort_url($field, $date, $status, $sort, $order)
                     </td>
                 <?php endif; ?>
                 <td>
-                        <a href="<?php echo site_url('booking/print_receipt/' . $b->id); ?>" class="btn btn-sm btn-secondary">Reprint</a>
+                        <a href="<?php echo site_url('booking/print_receipt/' . $b->id); ?>" class="btn btn-sm btn-secondary" title="Print nota" aria-label="Print nota"><i class="fas fa-print"></i></a>
                     </td>
             </tr>
         <?php endforeach; ?>

--- a/application/views/pos/index.php
+++ b/application/views/pos/index.php
@@ -15,7 +15,7 @@
             <select name="kategori" id="category-filter" class="form-control mr-2">
                 <option value="">Semua Kategori</option>
                 <?php foreach ($categories as $c): ?>
-                    <option value="<?php echo $c->kategori; ?>" <?php echo ($selected_category == $c->kategori) ? 'selected' : ''; ?>><?php echo htmlspecialchars($c->kategori); ?></option>
+                    <option value="<?php echo $c; ?>" <?php echo ($selected_category == $c) ? 'selected' : ''; ?>><?php echo htmlspecialchars($c); ?></option>
                 <?php endforeach; ?>
             </select>
             <input type="text" name="q" id="product-search" value="<?php echo htmlspecialchars($search_query); ?>" class="form-control mr-2" placeholder="Cari produk">

--- a/application/views/pos/transactions.php
+++ b/application/views/pos/transactions.php
@@ -27,7 +27,7 @@
                     <td><?php echo htmlspecialchars($s->customer_name ?: 'non member'); ?></td>
                     <td>Rp <?php echo number_format($s->total_belanja, 0, ',', '.'); ?></td>
                     <td><?php echo htmlspecialchars($s->tanggal_transaksi); ?></td>
-                    <td><a href="<?php echo site_url('pos/reprint/'.$s->id); ?>" class="btn btn-sm btn-secondary">Reprint</a></td>
+                    <td><a href="<?php echo site_url('pos/reprint/'.$s->id); ?>" class="btn btn-sm btn-secondary" title="Print nota" aria-label="Print nota"><i class="fas fa-print"></i></a></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>

--- a/application/views/products/export_excel.php
+++ b/application/views/products/export_excel.php
@@ -1,0 +1,25 @@
+<?php echo "\xEF\xBB\xBF"; // UTF-8 BOM for Excel ?>
+<table border="1">
+    <tr>
+        <th colspan="5"><?php echo $title; ?></th>
+    </tr>
+    <tr>
+        <td colspan="5">Tanggal: <?php echo $start_date ?: '-'; ?> s/d <?php echo $end_date ?: '-'; ?></td>
+    </tr>
+    <tr>
+        <th>ID</th>
+        <th>Nama Produk</th>
+        <th>Harga Jual</th>
+        <th>Stok</th>
+        <th>Kategori</th>
+    </tr>
+    <?php foreach ($products as $product): ?>
+    <tr>
+        <td><?php echo $product->id; ?></td>
+        <td><?php echo $product->nama_produk; ?></td>
+        <td><?php echo $product->harga_jual; ?></td>
+        <td><?php echo $product->stok; ?></td>
+        <td><?php echo $product->kategori; ?></td>
+    </tr>
+    <?php endforeach; ?>
+</table>

--- a/application/views/products/index.php
+++ b/application/views/products/index.php
@@ -4,7 +4,16 @@
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
 <?php endif; ?>
 <a href="<?php echo site_url('products/create'); ?>" class="btn btn-primary mb-2">Tambah Produk</a>
-<table class="table table-bordered">
+<form method="get" class="form-inline mb-3">
+    <input type="date" name="start_date" class="form-control mr-2" value="<?php echo html_escape($start_date); ?>">
+    <input type="date" name="end_date" class="form-control mr-2" value="<?php echo html_escape($end_date); ?>">
+    <button type="submit" class="btn btn-secondary">Filter</button>
+</form>
+
+<input type="text" id="productSearch" class="form-control mb-3 w-auto d-inline-block" style="max-width: 250px;" placeholder="Cari produk...">
+<small id="searchFeedback" class="form-text text-danger d-none">Produk tidak ditemukan</small>
+
+<table id="productsTable" class="table table-bordered">
     <thead>
         <tr>
             <th>ID</th>
@@ -31,4 +40,37 @@
     <?php endforeach; ?>
     </tbody>
 </table>
+
+<?php $params = http_build_query(['start_date' => $start_date, 'end_date' => $end_date]); ?>
+<a href="<?php echo site_url('products/export_excel?' . $params); ?>" class="btn btn-success mt-2">Export Excel</a>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const searchInput = document.getElementById('productSearch');
+    const table = document.getElementById('productsTable');
+    const feedback = document.getElementById('searchFeedback');
+
+    searchInput.addEventListener('keyup', function () {
+        const filter = searchInput.value.toLowerCase();
+        let visibleCount = 0;
+
+        const rows = table.getElementsByTagName('tr');
+        for (let i = 1; i < rows.length; i++) {
+            const text = rows[i].textContent.toLowerCase();
+            const match = text.indexOf(filter) > -1;
+            rows[i].style.display = match ? '' : 'none';
+            if (match) {
+                visibleCount++;
+            }
+        }
+
+        if (filter && visibleCount === 0) {
+            feedback.classList.remove('d-none');
+        } else {
+            feedback.classList.add('d-none');
+        }
+    });
+});
+</script>
+
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -12,6 +12,8 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
     <title>PadelPro</title>
     <!-- Bootstrap CSS via CDN -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- Font Awesome for icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-light bg-light">

--- a/database.sql
+++ b/database.sql
@@ -165,7 +165,8 @@ INSERT INTO `products` (`id`, `nama_produk`, `harga_jual`, `stok`, `kategori`, `
 (1, 'Hydro Coco', '10000.00', 999, 'minuman', '2025-08-26 01:45:49'),
 (2, 'Pocari Sweet', '10000.00', 999, 'minuman', '2025-08-26 01:46:01'),
 (3, 'Biskuit Imperial Creme', '5000.00', 99, 'makanan', '2025-08-26 01:47:17'),
-(4, 'Hydro Coco', '10000.00', 100, 'minuman', '2025-08-26 06:20:32');
+(4, 'Hydro Coco', '10000.00', 100, 'minuman', '2025-08-26 06:20:32'),
+(5, 'Raket Padel', '500000.00', 50, 'perlengkapan padel', '2025-08-26 06:30:00');
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- load Font Awesome for icon support
- replace text-based receipt actions with printer icons in booking schedule and POS transactions
- add live-validated search box to product list for instant filtering and feedback while shrinking the search box for a compact layout
- introduce a "Perlengkapan Padel" category to product management and seed data
- surface every product category in the POS transaction filter by sharing a single category list
- add date-filtered Excel export to the product list for offline reporting

## Testing
- `php -l application/controllers/Products.php`
- `php -l application/models/Product_model.php`
- `php -l application/views/pos/index.php`
- `php -l application/views/pos/transactions.php`
- `php -l application/views/booking/index.php`
- `php -l application/views/templates/header.php`
- `php -l application/views/products/index.php`
- `php -l application/views/products/export_excel.php`
- `composer test:coverage` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b60ac93c188320a74f2683f939fdc1