### PR TITLE
Hide reprint column for customers on booking schedule

### DIFF
--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -78,10 +78,10 @@ function booking_sort_url($field, $date, $status, $sort, $order)
                             </form>
                         <?php endif; ?>
                     </td>
-                <?php endif; ?>
-                <td>
+                    <td>
                         <a href="<?php echo site_url('booking/print_receipt/' . $b->id); ?>" class="btn btn-sm btn-secondary" title="Print nota" aria-label="Print nota"><i class="fas fa-print"></i></a>
                     </td>
+                <?php endif; ?>
             </tr>
         <?php endforeach; ?>
         </tbody>


### PR DESCRIPTION
## Summary
- show print receipt column only for cashier role in booking schedule

## Testing
- `php -l application/views/booking/index.php`
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b674236868832089fcd997f700110b