### PR TITLE
Hide reprint column for customers on booking schedule

### DIFF
--- a/application/controllers/Members.php
+++ b/application/controllers/Members.php
@@ -134,6 +134,25 @@ class Members extends CI_Controller
     }
 
     /**
+     * Pelanggan: tampilkan kartu member sederhana.
+     */
+    public function card()
+    {
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+        if ($this->session->userdata('role') !== 'pelanggan') {
+            show_error('Forbidden', 403);
+        }
+        $id = $this->session->userdata('id');
+        $data['member'] = $this->Member_model->get_by_id($id);
+        if (!$data['member']) {
+            show_404();
+        }
+        $this->load->view('members/card', $data);
+    }
+
+    /**
      * Pelanggan: tampilkan form untuk mengubah data member sendiri.
      */
     public function profile()

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -78,10 +78,10 @@ function booking_sort_url($field, $date, $status, $sort, $order)
                             </form>
                         <?php endif; ?>
                     </td>
-                <?php endif; ?>
-                <td>
+                    <td>
                         <a href="<?php echo site_url('booking/print_receipt/' . $b->id); ?>" class="btn btn-sm btn-secondary" title="Print nota" aria-label="Print nota"><i class="fas fa-print"></i></a>
                     </td>
+                <?php endif; ?>
             </tr>
         <?php endforeach; ?>
         </tbody>

--- a/application/views/members/card.php
+++ b/application/views/members/card.php
@@ -1,0 +1,10 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Member Card</h2>
+<div class="card mx-auto" style="width: 18rem;">
+    <img src="https://via.placeholder.com/150?text=Profile" class="card-img-top" alt="Profile Icon">
+    <div class="card-body text-center">
+        <h5 class="card-title"><?php echo htmlspecialchars($member->nama_lengkap); ?></h5>
+        <p class="card-text"><?php echo htmlspecialchars($member->kode_member); ?></p>
+    </div>
+</div>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -105,7 +105,11 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
                         Tanggal Toko: <?php echo htmlspecialchars($formatted_store_date); ?>
                     </span>
                 </li>
-                <li class="nav-item"><span class="navbar-text mr-3">Halo, <?php echo htmlspecialchars($this->session->userdata('nama_lengkap')); ?></span></li>
+                <?php if ($this->session->userdata('role') === 'pelanggan'): ?>
+                    <li class="nav-item"><a class="nav-link" href="<?php echo site_url('members/card'); ?>">Halo, pelanggan</a></li>
+                <?php else: ?>
+                    <li class="nav-item"><span class="navbar-text mr-3">Halo, <?php echo htmlspecialchars($this->session->userdata('nama_lengkap')); ?></span></li>
+                <?php endif; ?>
                 <!-- <li class="nav-item"><a class="nav-link" href="<?php echo site_url('users/profile'); ?>">Profil</a></li> -->
                 <li class="nav-item"><a class="nav-link" href="<?php echo site_url('auth/logout'); ?>">Logout</a></li>
             <?php else: ?>


### PR DESCRIPTION
## Summary
- show print receipt column only for cashier role in booking schedule
- add member card page accessible from 'Halo, pelanggan' header for customer role

## Testing
- `php -l application/controllers/Members.php`
- `php -l application/views/templates/header.php`
- `php -l application/views/members/card.php`
- `composer test` *(fails: Command "test" is not defined.)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b674236868832089fcd997f700110b