### PR TITLE
Add payment proof preview to booking views

### DIFF
--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -41,7 +41,7 @@ function booking_sort_url($field, $date, $status, $sort, $order)
                 <th><a href="<?php echo htmlspecialchars(booking_sort_url('status_booking', $date, $status, $sort, $order)); ?>">Status</a></th>
                 <th><a href="<?php echo htmlspecialchars(booking_sort_url('keterangan', $date, $status, $sort, $order)); ?>">Keterangan</a></th>
                 <?php if ($role === 'kasir'): ?>
-                    
+                    <th>Bukti Pembayaran</th>
                     <th style="width:280px;">Aksi</th>
                     <th>Nota</th>
                 <?php endif; ?>
@@ -58,7 +58,13 @@ function booking_sort_url($field, $date, $status, $sort, $order)
                 <td><?php echo htmlspecialchars($b->status_booking); ?></td>
                 <td><?php echo htmlspecialchars($b->keterangan); ?></td>
                 <?php if ($role === 'kasir'): ?>
-                    
+                    <td>
+                        <?php if (!empty($b->bukti_pembayaran)): ?>
+                            <a href="#" class="preview-bukti" data-image="<?php echo base_url('uploads/payment_proofs/' . $b->bukti_pembayaran); ?>" title="Lihat bukti" aria-label="Lihat bukti"><i class="fas fa-eye"></i></a>
+                        <?php else: ?>
+                            -
+                        <?php endif; ?>
+                    </td>
                     <td style="width:280px;">
                         <?php if ($b->status_booking === 'pending'): ?>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
@@ -197,5 +203,28 @@ if (table) {
 
     renderTable();
 }
+</script>
+<div class="modal fade" id="buktiModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-body text-center">
+                <img src="" alt="Bukti Pembayaran" class="img-fluid">
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var links = document.querySelectorAll('.preview-bukti');
+    links.forEach(function(link) {
+        link.addEventListener('click', function(e) {
+            e.preventDefault();
+            var imgSrc = this.getAttribute('data-image');
+            var modalImg = document.querySelector('#buktiModal img');
+            modalImg.src = imgSrc;
+            $('#buktiModal').modal('show');
+        });
+    });
+});
 </script>
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/booking/my.php
+++ b/application/views/booking/my.php
@@ -13,6 +13,7 @@
             <th>Jam Selesai</th>
             <th>Status</th>
             <th>Keterangan</th>
+            <th>Bukti Pembayaran</th>
         </tr>
     </thead>
     <tbody>
@@ -24,10 +25,40 @@
             <td><?php echo htmlspecialchars($b->jam_selesai); ?></td>
             <td><?php echo htmlspecialchars(ucfirst($b->status_booking)); ?></td>
             <td><?php echo htmlspecialchars($b->keterangan); ?></td>
+            <td>
+                <?php if (!empty($b->bukti_pembayaran)): ?>
+                    <a href="#" class="preview-bukti" data-image="<?php echo base_url('uploads/payment_proofs/' . $b->bukti_pembayaran); ?>" title="Lihat bukti" aria-label="Lihat bukti"><i class="fas fa-eye"></i></a>
+                <?php else: ?>
+                    -
+                <?php endif; ?>
+            </td>
         </tr>
         <?php endforeach; ?>
     </tbody>
 </table>
 <?php endif; ?>
+<div class="modal fade" id="buktiModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-body text-center">
+                <img src="" alt="Bukti Pembayaran" class="img-fluid">
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var links = document.querySelectorAll('.preview-bukti');
+    links.forEach(function(link) {
+        link.addEventListener('click', function(e) {
+            e.preventDefault();
+            var imgSrc = this.getAttribute('data-image');
+            var modalImg = document.querySelector('#buktiModal img');
+            modalImg.src = imgSrc;
+            $('#buktiModal').modal('show');
+        });
+    });
+});
+</script>
 <?php $this->load->view('templates/footer'); ?>
 


### PR DESCRIPTION
## Summary
- show payment proof column with preview icon on cashier booking schedule
- allow customers to preview payment proofs in "Booking Saya"

## Testing
- `php -l application/views/booking/index.php`
- `php -l application/views/booking/my.php`


------
https://chatgpt.com/codex/tasks/task_e_68b69d45bbcc8320b5a122a8f3c7dd48