### PR TITLE
Add payment proof preview and date range filter to booking views

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -21,29 +21,34 @@ class Booking extends CI_Controller
     }
 
     /**
-     * Tampilkan jadwal ketersediaan lapangan untuk tanggal tertentu.
+     * Tampilkan jadwal ketersediaan lapangan untuk rentang tanggal tertentu.
      */
     public function index()
     {
         if (!$this->session->userdata('logged_in')) {
             redirect('auth/login');
         }
-        $date   = $this->input->get('date');
-        if (!$date) {
-            $date = date('Y-m-d');
+        $start  = $this->input->get('start_date');
+        $end    = $this->input->get('end_date');
+        if (!$start) {
+            $start = date('Y-m-d');
+        }
+        if (!$end) {
+            $end = $start;
         }
         $status = $this->input->get('status');
         $sort   = $this->input->get('sort') ?: 'jam_mulai';
         $order  = $this->input->get('order') ?: 'asc';
-        $data['date']   = $date;
-        $data['sort']   = $sort;
-        $data['order']  = $order;
-        $data['status'] = $status;
-        $data['courts'] = $this->Court_model->get_all();
+        $data['start_date'] = $start;
+        $data['end_date']   = $end;
+        $data['sort']       = $sort;
+        $data['order']      = $order;
+        $data['status']     = $status;
+        $data['courts']     = $this->Court_model->get_all();
         if ($status === 'pending') {
             $data['bookings'] = $this->Booking_model->get_pending($sort, $order);
         } else {
-            $data['bookings'] = $this->Booking_model->get_by_date($date, $sort, $order);
+            $data['bookings'] = $this->Booking_model->get_by_date_range($start, $end, $sort, $order);
         }
         $this->load->view('booking/index', $data);
     }

--- a/application/models/Booking_model.php
+++ b/application/models/Booking_model.php
@@ -33,6 +33,32 @@ class Booking_model extends CI_Model
                         ->result();
     }
 
+    public function get_by_date_range($start, $end, $sort = 'jam_mulai', $order = 'asc')
+    {
+        $allowed = [
+            'id_court'       => 'courts.nama_lapangan',
+            'kode_member'    => 'm.kode_member',
+            'tanggal_booking'=> 'bookings.tanggal_booking',
+            'jam_mulai'      => 'bookings.jam_mulai',
+            'jam_selesai'    => 'bookings.jam_selesai',
+            'status_pembayaran' => 'bookings.status_pembayaran',
+            'status_booking' => 'bookings.status_booking',
+            'keterangan'     => 'bookings.keterangan'
+        ];
+        $sort_field = isset($allowed[$sort]) ? $allowed[$sort] : $allowed['jam_mulai'];
+        $order      = strtolower($order) === 'desc' ? 'desc' : 'asc';
+        return $this->db->select('bookings.*, m.kode_member, courts.nama_lapangan')
+                        ->from($this->table)
+                        ->join('member_data m', 'm.user_id = bookings.id_user', 'left')
+                        ->join('courts', 'courts.id = bookings.id_court', 'left')
+                        ->where('bookings.tanggal_booking >=', $start)
+                        ->where('bookings.tanggal_booking <=', $end)
+                        ->where('bookings.status_booking !=', 'batal')
+                        ->order_by($sort_field, $order)
+                        ->get()
+                        ->result();
+    }
+
     public function get_pending($sort = 'jam_mulai', $order = 'asc')
     {
         $allowed = [

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -1,30 +1,34 @@
 <?php $this->load->view('templates/header'); ?>
 <?php $role  = $this->session->userdata('role'); ?>
-<?php $sort   = isset($sort) ? $sort : 'jam_mulai'; ?>
-<?php $order  = isset($order) ? $order : 'asc'; ?>
-<?php $status = isset($status) ? $status : ''; ?>
+<?php $sort        = isset($sort) ? $sort : 'jam_mulai'; ?>
+<?php $order       = isset($order) ? $order : 'asc'; ?>
+<?php $status      = isset($status) ? $status : ''; ?>
+<?php $start_date  = isset($start_date) ? $start_date : date('Y-m-d'); ?>
+<?php $end_date    = isset($end_date) ? $end_date : $start_date; ?>
 <?php
-function booking_sort_url($field, $date, $status, $sort, $order)
+function booking_sort_url($field, $start, $end, $status, $sort, $order)
 {
     $next = ($sort === $field && $order === 'asc') ? 'desc' : 'asc';
     if ($status === 'pending') {
         return site_url('booking') . '?status=pending&sort=' . $field . '&order=' . $next;
     }
-    return site_url('booking') . '?date=' . urlencode($date) . '&sort=' . $field . '&order=' . $next;
+    return site_url('booking') . '?start_date=' . urlencode($start) . '&end_date=' . urlencode($end) . '&sort=' . $field . '&order=' . $next;
 }
 ?>
 <h2>Jadwal Booking Lapangan</h2>
 <form method="get" class="form-inline mb-3">
-    <label for="date" class="mr-2">Tanggal:</label>
-    <input type="date" id="date" name="date" class="form-control mr-2" value="<?php echo htmlspecialchars($date); ?>">
+    <label for="start_date" class="mr-2">Dari:</label>
+    <input type="date" id="start_date" name="start_date" class="form-control mr-2" value="<?php echo htmlspecialchars($start_date); ?>">
+    <label for="end_date" class="mr-2">Sampai:</label>
+    <input type="date" id="end_date" name="end_date" class="form-control mr-2" value="<?php echo htmlspecialchars($end_date); ?>">
     <?php if ($role !== 'pelanggan'): ?>
         <label for="status" class="mr-2">Status:</label>
         <select id="status" name="status" class="form-control mr-2">
             <option value="">Semua</option>
-            <option value="pending" <?php echo isset($status) && $status === 'pending' ? 'selected' : ''; ?>>Pending</option>
+            <option value="pending" <?php echo $status === 'pending' ? 'selected' : ''; ?>>Pending</option>
         </select>
-        <button type="submit" class="btn btn-primary">Lihat</button>
     <?php endif; ?>
+    <button type="submit" class="btn btn-primary">Lihat</button>
     <a href="<?php echo site_url('booking/create'); ?>" class="btn btn-success ml-2">Booking Baru</a>
 </form>
 <input type="text" id="search" class="form-control mb-3" placeholder="Cari booking..." style="width:250px;">
@@ -33,15 +37,15 @@ function booking_sort_url($field, $date, $status, $sort, $order)
     <table class="table table-bordered" id="booking-table">
         <thead>
             <tr>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('tanggal_booking', $date, $status, $sort, $order)); ?>">Tanggal</a></th>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('id_court', $date, $status, $sort, $order)); ?>">Lapangan</a></th>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('jam_mulai', $date, $status, $sort, $order)); ?>">Jam Mulai</a></th>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('jam_selesai', $date, $status, $sort, $order)); ?>">Jam Selesai</a></th>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('kode_member', $date, $status, $sort, $order)); ?>">Kode Member</a></th>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('status_booking', $date, $status, $sort, $order)); ?>">Status</a></th>
-                <th><a href="<?php echo htmlspecialchars(booking_sort_url('keterangan', $date, $status, $sort, $order)); ?>">Keterangan</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('tanggal_booking', $start_date, $end_date, $status, $sort, $order)); ?>">Tanggal</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('id_court', $start_date, $end_date, $status, $sort, $order)); ?>">Lapangan</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('jam_mulai', $start_date, $end_date, $status, $sort, $order)); ?>">Jam Mulai</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('jam_selesai', $start_date, $end_date, $status, $sort, $order)); ?>">Jam Selesai</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('kode_member', $start_date, $end_date, $status, $sort, $order)); ?>">Kode Member</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('status_booking', $start_date, $end_date, $status, $sort, $order)); ?>">Status</a></th>
+                <th><a href="<?php echo htmlspecialchars(booking_sort_url('keterangan', $start_date, $end_date, $status, $sort, $order)); ?>">Keterangan</a></th>
                 <?php if ($role === 'kasir'): ?>
-                    
+                    <th>Bukti Pembayaran</th>
                     <th style="width:280px;">Aksi</th>
                     <th>Nota</th>
                 <?php endif; ?>
@@ -58,7 +62,13 @@ function booking_sort_url($field, $date, $status, $sort, $order)
                 <td><?php echo htmlspecialchars($b->status_booking); ?></td>
                 <td><?php echo htmlspecialchars($b->keterangan); ?></td>
                 <?php if ($role === 'kasir'): ?>
-                    
+                    <td>
+                        <?php if (!empty($b->bukti_pembayaran)): ?>
+                            <a href="#" class="preview-bukti" data-image="<?php echo base_url('uploads/payment_proofs/' . $b->bukti_pembayaran); ?>" title="Lihat bukti" aria-label="Lihat bukti"><i class="fas fa-eye"></i></a>
+                        <?php else: ?>
+                            -
+                        <?php endif; ?>
+                    </td>
                     <td style="width:280px;">
                         <?php if ($b->status_booking === 'pending'): ?>
                             <form method="post" action="<?php echo site_url('booking/update_status/' . $b->id); ?>" style="display:inline-block">
@@ -101,13 +111,15 @@ function booking_sort_url($field, $date, $status, $sort, $order)
         </nav>
     </div>
 <?php else: ?>
-    <p>Tidak ada booking pada tanggal ini.</p>
+    <p>Tidak ada booking pada rentang tanggal ini.</p>
 <?php endif; ?>
 <script>
 var statusEl = document.getElementById('status');
 if (statusEl) {
     statusEl.addEventListener('change', function() {
-        document.getElementById('date').disabled = this.value === 'pending';
+        var disabled = this.value === 'pending';
+        document.getElementById('start_date').disabled = disabled;
+        document.getElementById('end_date').disabled = disabled;
     });
     statusEl.dispatchEvent(new Event('change'));
 }
@@ -197,5 +209,28 @@ if (table) {
 
     renderTable();
 }
+</script>
+<div class="modal fade" id="buktiModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-body text-center">
+                <img src="" alt="Bukti Pembayaran" class="img-fluid">
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var links = document.querySelectorAll('.preview-bukti');
+    links.forEach(function(link) {
+        link.addEventListener('click', function(e) {
+            e.preventDefault();
+            var imgSrc = this.getAttribute('data-image');
+            var modalImg = document.querySelector('#buktiModal img');
+            modalImg.src = imgSrc;
+            $('#buktiModal').modal('show');
+        });
+    });
+});
 </script>
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/booking/my.php
+++ b/application/views/booking/my.php
@@ -13,6 +13,7 @@
             <th>Jam Selesai</th>
             <th>Status</th>
             <th>Keterangan</th>
+            <th>Bukti Pembayaran</th>
         </tr>
     </thead>
     <tbody>
@@ -24,10 +25,40 @@
             <td><?php echo htmlspecialchars($b->jam_selesai); ?></td>
             <td><?php echo htmlspecialchars(ucfirst($b->status_booking)); ?></td>
             <td><?php echo htmlspecialchars($b->keterangan); ?></td>
+            <td>
+                <?php if (!empty($b->bukti_pembayaran)): ?>
+                    <a href="#" class="preview-bukti" data-image="<?php echo base_url('uploads/payment_proofs/' . $b->bukti_pembayaran); ?>" title="Lihat bukti" aria-label="Lihat bukti"><i class="fas fa-eye"></i></a>
+                <?php else: ?>
+                    -
+                <?php endif; ?>
+            </td>
         </tr>
         <?php endforeach; ?>
     </tbody>
 </table>
 <?php endif; ?>
+<div class="modal fade" id="buktiModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-body text-center">
+                <img src="" alt="Bukti Pembayaran" class="img-fluid">
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var links = document.querySelectorAll('.preview-bukti');
+    links.forEach(function(link) {
+        link.addEventListener('click', function(e) {
+            e.preventDefault();
+            var imgSrc = this.getAttribute('data-image');
+            var modalImg = document.querySelector('#buktiModal img');
+            modalImg.src = imgSrc;
+            $('#buktiModal').modal('show');
+        });
+    });
+});
+</script>
 <?php $this->load->view('templates/footer'); ?>
 


### PR DESCRIPTION
## Summary
- show payment proof column with preview icon on cashier booking schedule
- allow customers to preview payment proofs in "Booking Saya"
- filter booking schedule by a start/end date range like the finance menu

## Testing
- `php -l application/views/booking/index.php`
- `php -l application/controllers/Booking.php`
- `php -l application/models/Booking_model.php`


------
https://chatgpt.com/codex/tasks/task_e_68b69d45bbcc8320b5a122a8f3c7dd48