### PR TITLE
Add daily booking code generation

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -319,7 +319,7 @@ class Booking extends CI_Controller
         }
         $printer->text(str_repeat('-', 32) . "\n");
         $printer->setJustification(Printer::JUSTIFY_LEFT);
-        $printer->text('ID Booking : ' . $booking->id . "\n");
+        $printer->text('ID Booking : ' . $booking->booking_code . "\n");
         $printer->text('Tanggal    : ' . $booking->tanggal_booking . "\n");
         $printer->text('Lapangan   : ' . $booking->nama_lapangan . "\n");
         $printer->text('Mulai      : ' . $booking->jam_mulai . "\n");

--- a/application/models/Booking_model.php
+++ b/application/models/Booking_model.php
@@ -8,6 +8,22 @@ class Booking_model extends CI_Model
 {
     protected $table = 'bookings';
 
+    /**
+     * Generate a booking code with format YYMMDD-XXXX where XXXX
+     * is the incremental number of bookings for the current day.
+     */
+    private function generate_booking_code()
+    {
+        $prefix = date('ymd') . '-';
+        $this->db->like('booking_code', $prefix, 'after');
+        $this->db->select('booking_code');
+        $this->db->order_by('booking_code', 'desc');
+        $this->db->limit(1);
+        $last = $this->db->get($this->table)->row();
+        $num  = $last ? (int) substr($last->booking_code, 7) : 0;
+        return $prefix . sprintf('%04d', $num + 1);
+    }
+
     public function get_by_date($date, $sort = 'jam_mulai', $order = 'asc')
     {
         $allowed = [
@@ -98,6 +114,7 @@ class Booking_model extends CI_Model
 
     public function insert($data)
     {
+        $data['booking_code'] = $this->generate_booking_code();
         $this->db->insert($this->table, $data);
         return $this->db->insert_id();
     }

--- a/application/models/Report_model.php
+++ b/application/models/Report_model.php
@@ -68,7 +68,7 @@ class Report_model extends CI_Model
             ];
         }
         if ($category === 'booking') {
-            $this->db->select('id, tanggal_booking, total_harga');
+            $this->db->select('id, booking_code, tanggal_booking, total_harga');
             $this->db->from('bookings');
             $this->db->where('tanggal_booking >=', $start);
             $this->db->where('tanggal_booking <=', $end);
@@ -77,13 +77,13 @@ class Report_model extends CI_Model
             foreach ($rows as $b) {
                 $details[] = [
                     'tanggal'     => $b->tanggal_booking,
-                    'keterangan'  => 'Booking #' . $b->id,
+                    'keterangan'  => 'Booking #' . $b->booking_code,
                     'uang_masuk'  => (float) $b->total_harga,
                     'uang_keluar' => 0,
                 ];
             }
         } elseif ($category === 'batal') {
-            $this->db->select('id, tanggal_booking, total_harga');
+            $this->db->select('id, booking_code, tanggal_booking, total_harga');
             $this->db->from('bookings');
             $this->db->where('tanggal_booking >=', $start);
             $this->db->where('tanggal_booking <=', $end);
@@ -92,7 +92,7 @@ class Report_model extends CI_Model
             foreach ($rows as $b) {
                 $details[] = [
                     'tanggal'     => $b->tanggal_booking,
-                    'keterangan'  => 'Booking batal #' . $b->id,
+                    'keterangan'  => 'Booking batal #' . $b->booking_code,
                     'uang_masuk'  => 0,
                     'uang_keluar' => (float) $b->total_harga,
                 ];

--- a/application/views/booking/receipt.php
+++ b/application/views/booking/receipt.php
@@ -18,7 +18,7 @@
 <div class="receipt">
     <h2>Nota Booking</h2>
     <table>
-        <tr><td>ID Booking</td><td>: <?= $booking->id ?></td></tr>
+        <tr><td>ID Booking</td><td>: <?= $booking->booking_code ?></td></tr>
         <tr><td>Tanggal</td><td>: <?= $booking->tanggal_booking ?></td></tr>
         <tr><td>Lapangan</td><td>: <?= $booking->nama_lapangan ?></td></tr>
         <tr><td>Mulai</td><td>: <?= $booking->jam_mulai ?></td></tr>

--- a/database.sql
+++ b/database.sql
@@ -30,6 +30,7 @@ SET time_zone = "+00:00";
 
 CREATE TABLE `bookings` (
   `id` int(11) NOT NULL,
+  `booking_code` varchar(20) NOT NULL,
   `id_user` int(11) NOT NULL,
   `id_court` int(11) NOT NULL,
   `tanggal_booking` date NOT NULL,
@@ -50,13 +51,13 @@ CREATE TABLE `bookings` (
 -- Dumping data for table `bookings`
 --
 
-INSERT INTO `bookings` (`id`, `id_user`, `id_court`, `tanggal_booking`, `jam_mulai`, `jam_selesai`, `durasi`, `harga_booking`, `diskon`, `total_harga`, `status_booking`, `keterangan`, `bukti_pembayaran`, `status_pembayaran`, `created_at`) VALUES
-(1, 1, 1, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 01:59:44'),
-(2, 1, 1, '2025-08-27', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:00:29'),
-(3, 3, 2, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, NULL, 'belum_bayar', '2025-08-25 02:27:04'),
-(4, 3, 3, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'batal', '', NULL, 'belum_bayar', '2025-08-25 02:33:16'),
-(5, 1, 1, '2025-08-25', '14:00:00', '15:00:00', 60, '300000.00', '0.00', '300000.00', 'batal', '', NULL, 'belum_bayar', '2025-08-26 02:38:42'),
-(6, 1, 2, '2025-08-24', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:39:50');
+INSERT INTO `bookings` (`id`, `booking_code`, `id_user`, `id_court`, `tanggal_booking`, `jam_mulai`, `jam_selesai`, `durasi`, `harga_booking`, `diskon`, `total_harga`, `status_booking`, `keterangan`, `bukti_pembayaran`, `status_pembayaran`, `created_at`) VALUES
+(1, '250826-0001', 1, 1, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 01:59:44'),
+(2, '250826-0002', 1, 1, '2025-08-27', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:00:29'),
+(3, '250825-0001', 3, 2, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, NULL, 'belum_bayar', '2025-08-25 02:27:04'),
+(4, '250825-0002', 3, 3, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'batal', '', NULL, 'belum_bayar', '2025-08-25 02:33:16'),
+(5, '250826-0003', 1, 1, '2025-08-25', '14:00:00', '15:00:00', 60, '300000.00', '0.00', '300000.00', 'batal', '', NULL, 'belum_bayar', '2025-08-26 02:38:42'),
+(6, '250826-0004', 1, 2, '2025-08-24', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:39:50');
 
 -- --------------------------------------------------------
 
@@ -270,6 +271,7 @@ INSERT INTO `users` (`id`, `nama_lengkap`, `email`, `password`, `no_telepon`, `r
 --
 ALTER TABLE `bookings`
   ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `booking_code` (`booking_code`),
   ADD KEY `id_user` (`id_user`),
   ADD KEY `id_court` (`id_court`);
 


### PR DESCRIPTION
## Summary
- add `booking_code` column to bookings table with unique index
- generate daily sequential booking codes in `Booking_model`
- show formatted booking codes on receipts and printed output
- use booking codes instead of numeric IDs in finance report descriptions

## Testing
- `php -l application/models/Booking_model.php`
- `php -l application/controllers/Booking.php`
- `php -l application/views/booking/receipt.php`
- `php -l application/models/Report_model.php`
- `php -l application/views/finance/index.php`
- `composer test:coverage` *(fails: phpunit: not found)*
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b6afa4dcb08320963c8db611d1ddcc