### PR TITLE
Add live phone number validation

### DIFF
--- a/application/controllers/Auth.php
+++ b/application/controllers/Auth.php
@@ -67,7 +67,7 @@ class Auth extends CI_Controller
             $this->form_validation->set_rules('email', 'Email', 'required|valid_email|is_unique[users.email]', [
                 'is_unique' => 'Email sudah digunakan.'
             ]);
-            $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|is_unique[users.no_telepon]', [
+            $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|numeric|min_length[10]|is_unique[users.no_telepon]', [
                 'is_unique' => 'No telepon sudah digunakan.'
             ]);
             $this->form_validation->set_rules('password', 'Password', 'required|min_length[6]');

--- a/application/controllers/Members.php
+++ b/application/controllers/Members.php
@@ -61,7 +61,7 @@ class Members extends CI_Controller
         $this->authorize();
         $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
         $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check');
-        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|callback_phone_check');
+        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|numeric|min_length[10]|callback_phone_check');
         $this->form_validation->set_rules('password', 'Password', 'required|min_length[6]');
         $this->form_validation->set_rules('alamat', 'Alamat', 'required');
         $this->form_validation->set_rules('kecamatan', 'Kecamatan', 'required');
@@ -104,7 +104,7 @@ class Members extends CI_Controller
         $this->authorize();
         $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
         $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check['.$id.']');
-        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|callback_phone_check['.$id.']');
+        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|numeric|min_length[10]|callback_phone_check['.$id.']');
         $this->form_validation->set_rules('alamat', 'Alamat', 'required');
         $this->form_validation->set_rules('kecamatan', 'Kecamatan', 'required');
         $this->form_validation->set_rules('kota', 'Kota', 'required');
@@ -186,7 +186,7 @@ class Members extends CI_Controller
 
         $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
         $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check['.$id.']');
-        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|callback_phone_check['.$id.']');
+        $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|numeric|min_length[10]|callback_phone_check['.$id.']');
         if ($this->input->post('password')) {
             $this->form_validation->set_rules('password', 'Password', 'min_length[6]');
         }

--- a/application/controllers/Users.php
+++ b/application/controllers/Users.php
@@ -63,6 +63,7 @@ class Users extends CI_Controller
         if ($this->input->method() === 'post') {
             $this->form_validation->set_rules('nama_lengkap', 'Nama Lengkap', 'required');
             $this->form_validation->set_rules('email', 'Email', 'required|valid_email');
+            $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|numeric|min_length[10]');
             if ($this->input->post('password')) {
                 $this->form_validation->set_rules('password', 'Password', 'min_length[6]');
             }

--- a/application/views/templates/footer.php
+++ b/application/views/templates/footer.php
@@ -4,5 +4,20 @@
 <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var phoneInputs = document.querySelectorAll('input[name="no_telepon"], #modal-phone, #customer-phone');
+    phoneInputs.forEach(function(input) {
+        input.addEventListener('input', function() {
+            this.value = this.value.replace(/[^0-9]/g, '');
+            if (this.value.length < 10) {
+                this.setCustomValidity('Masukkan minimal 10 digit angka');
+            } else {
+                this.setCustomValidity('');
+            }
+        });
+    });
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enforce numeric phone numbers with minimum 10 digits across member, auth and user controllers
- add global script to restrict phone inputs to digits and validate length live

## Testing
- `php -l application/controllers/Members.php`
- `php -l application/controllers/Auth.php`
- `php -l application/controllers/Users.php`
- `php -l application/views/templates/footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7d65d48d483209d84a2374bacd02f