### PR TITLE
Replace printer receipt with downloadable text file

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -1,9 +1,7 @@
 <?php
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-use Mike42\Escpos\Printer;
-use Mike42\Escpos\PrintConnectors\WindowsPrintConnector;
-use Mike42\Escpos\CapabilityProfile;
+// Printer libraries removed - receipts will be downloaded as text files
 
 /**
  * Controller untuk modul booking pelanggan.
@@ -298,52 +296,35 @@ class Booking extends CI_Controller
         if (!$booking) {
             show_404();
         }
+
         $member = $this->Member_model->get_by_id($booking->id_user);
 
-        try {
-            $profile = CapabilityProfile::load('T82');
-        } catch (\Exception $e) {
-            $profile = CapabilityProfile::load('default');
+        // Build receipt content
+        $lines = [];
+        $lines[] = 'Padel Store';
+        $lines[] = date('d-m-Y H:i');
+        if ($member && !empty($member->kode_member)) {
+            $lines[] = 'Nomor Member: ' . $member->kode_member;
+        } else {
+            $lines[] = '-Non Member-';
         }
+        $lines[] = str_repeat('-', 32);
+        $lines[] = 'ID Booking : ' . $booking->booking_code;
+        $lines[] = 'Tanggal    : ' . $booking->tanggal_booking;
+        $lines[] = 'Lapangan   : ' . $booking->nama_lapangan;
+        $lines[] = 'Mulai      : ' . $booking->jam_mulai;
+        $lines[] = 'Selesai    : ' . $booking->jam_selesai;
+        $lines[] = 'Durasi     : ' . $booking->durasi . ' menit';
+        $lines[] = 'Harga      : Rp ' . number_format($booking->harga_booking,0,',','.');
+        $lines[] = 'Diskon     : Rp ' . number_format($booking->diskon,0,',','.');
+        $lines[] = 'Total      : Rp ' . number_format($booking->total_harga,0,',','.');
+        $lines[] = '';
 
-        try {
-            $connector = new WindowsPrintConnector('T82');
-            $printer   = new Printer($connector, $profile);
-            $printer->setPrintLeftMargin(80);
-            $printer->setJustification(Printer::JUSTIFY_CENTER);
-            $printer->text("Padel Store\n");
-            $printer->text(date('d-m-Y H:i') . "\n");
-            if ($member && !empty($member->kode_member)) {
-                $printer->text('Nomor Member: ' . $member->kode_member . "\n");
-            } else {
-                $printer->text("-Non Member-\n");
-            }
-            $printer->text(str_repeat('-', 32) . "\n");
-            $printer->setJustification(Printer::JUSTIFY_LEFT);
-            $printer->text('ID Booking : ' . $booking->booking_code . "\n");
-            $printer->text('Tanggal    : ' . $booking->tanggal_booking . "\n");
-            $printer->text('Lapangan   : ' . $booking->nama_lapangan . "\n");
-            $printer->text('Mulai      : ' . $booking->jam_mulai . "\n");
-            $printer->text('Selesai    : ' . $booking->jam_selesai . "\n");
-            $printer->text('Durasi     : ' . $booking->durasi . " menit\n");
-            $printer->text('Harga      : Rp ' . number_format($booking->harga_booking,0,',','.') . "\n");
-            $printer->text('Diskon     : Rp ' . number_format($booking->diskon,0,',','.') . "\n");
-            $printer->text('Total      : Rp ' . number_format($booking->total_harga,0,',','.') . "\n");
-            $printer->feed(2);
-            $printer->cut();
-            $printer->close();
-            $this->session->set_flashdata('success', 'Nota berhasil dicetak.');
-        } catch (\Exception $e) {
-            if (isset($printer) && $printer instanceof Printer) {
-                try {
-                    $printer->close();
-                } catch (\Exception $ex) {
-                    // ignore
-                }
-            }
-            $this->session->set_flashdata('error', 'Nota tidak tercetak. Alasan: ' . $e->getMessage());
-        }
-        redirect('booking');
+        $content  = implode("\n", $lines);
+        $filename = 'nota_' . $booking->booking_code . '.txt';
+
+        $this->load->helper('download');
+        force_download($filename, $content);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Remove Epson T82 printer usage for booking receipts
- Generate booking receipts as downloadable `.txt` files

## Testing
- `php -l application/controllers/Booking.php`


------
https://chatgpt.com/codex/tasks/task_e_68b90c0c47cc8320bd2a6da9de7e0591