### PR TITLE
Add custom booking option on dashboard

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -144,6 +144,13 @@ class Booking extends CI_Controller
             }
             $start  = $this->input->post('jam_mulai');
             $end    = $this->input->post('jam_selesai');
+            $open   = '08:00';
+            $close  = '22:00';
+            if (strtotime($start) < strtotime($open) || strtotime($end) > strtotime($close)) {
+                $this->session->set_flashdata('error', 'Jam booking harus antara 08:00 dan 22:00.');
+                redirect('booking/create');
+                return;
+            }
             $durasi = (strtotime($end) - strtotime($start)) / 60; // minutes
             if ($durasi <= 0) {
                 $this->session->set_flashdata('error', 'Jam selesai harus lebih besar dari jam mulai.');

--- a/application/views/booking/create.php
+++ b/application/views/booking/create.php
@@ -48,11 +48,11 @@
     </div>
     <div class="form-group">
         <label for="jam_mulai">Jam Mulai</label>
-        <input type="time" name="jam_mulai" id="jam_mulai" class="form-control" value="<?php echo set_value('jam_mulai', isset($selected_start) ? $selected_start : ''); ?>" required>
+        <input type="time" name="jam_mulai" id="jam_mulai" class="form-control" min="08:00" max="22:00" value="<?php echo set_value('jam_mulai', isset($selected_start) ? $selected_start : ''); ?>" required>
     </div>
     <div class="form-group">
         <label for="jam_selesai">Jam Selesai</label>
-        <input type="time" name="jam_selesai" id="jam_selesai" class="form-control" value="<?php echo set_value('jam_selesai', isset($selected_end) ? $selected_end : ''); ?>" required>
+        <input type="time" name="jam_selesai" id="jam_selesai" class="form-control" min="08:00" max="22:00" value="<?php echo set_value('jam_selesai', isset($selected_end) ? $selected_end : ''); ?>" required>
     </div>
 <?php if ($this->session->userdata('role') === 'pelanggan'): ?>
     <div class="form-group">

--- a/application/views/dashboard/customer.php
+++ b/application/views/dashboard/customer.php
@@ -1,6 +1,6 @@
 <?php $this->load->view('templates/header'); ?>
 <h2>Dashboard Pelanggan</h2>
-<p>Hey Padel Lovers! 🎾 Mau pesan lapangan di jam custom? Tekan saja Booking Sekarang tanpa pilih jadwal—lebih fleksibel dan gampang!</p>
+<p>Hey Padel Lovers! 🎾 Mau pesan lapangan di jam custom? Pilih opsi <strong>Custom</strong> lalu tekan Booking Sekarang—lebih fleksibel dan gampang!</p>
 <div class="row">
     <?php if (!empty($courts)): ?>
         <?php foreach ($courts as $court): ?>
@@ -24,9 +24,19 @@
                                             </div>
                                         </li>
                                     <?php endforeach; ?>
+                                    <li class="col-6">
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="radio" name="slot" id="slot_<?php echo $court->id; ?>_custom" value="custom">
+                                            <label class="form-check-label" for="slot_<?php echo $court->id; ?>_custom">Custom</label>
+                                        </div>
+                                    </li>
                                 </ul>
                             <?php else: ?>
                                 <p class="card-text mb-3">Tidak ada jadwal kosong hari ini.</p>
+                                <div class="form-check mb-3">
+                                    <input class="form-check-input" type="radio" name="slot" id="slot_<?php echo $court->id; ?>_custom" value="custom">
+                                    <label class="form-check-label" for="slot_<?php echo $court->id; ?>_custom">Custom</label>
+                                </div>
                             <?php endif; ?>
                             <button type="submit" class="btn btn-primary mt-auto">Booking Sekarang</button>
                         </form>


### PR DESCRIPTION
## Summary
- Add clear instructions and a "Custom" radio option on the customer dashboard so players can request custom booking times.
- Include fallback custom option when no preset slots are available.
- Restrict booking start and end times between 08:00 and 22:00 for all users.

## Testing
- `composer install` *(fails: curl error 56 - CONNECT tunnel failed, response 403)*
- `composer test:coverage` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e0cf9048320b993987b4f4ee3bd