### PR TITLE
Add member point system and reward redemption

### DIFF
--- a/application/controllers/Points.php
+++ b/application/controllers/Points.php
@@ -1,0 +1,38 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Points extends CI_Controller
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->library('session');
+        $this->load->helper(['url','form']);
+        $this->load->model('Point_rule_model');
+    }
+
+    private function authorize()
+    {
+        if (!$this->session->userdata('logged_in') || $this->session->userdata('role') !== 'owner') {
+            show_error('Forbidden', 403);
+        }
+    }
+
+    public function index()
+    {
+        $this->authorize();
+        if ($this->input->method() === 'post') {
+            $product = (int) $this->input->post('product_rate');
+            $booking = (int) $this->input->post('booking_rate');
+            if ($product > 0 && $booking > 0) {
+                $this->Point_rule_model->update($product, $booking);
+                $this->session->set_flashdata('success', 'Ketentuan poin diperbarui.');
+            }
+            redirect('points');
+            return;
+        }
+        $data['rules'] = $this->Point_rule_model->get();
+        $this->load->view('points/rules', $data);
+    }
+}
+?>

--- a/application/controllers/Rewards.php
+++ b/application/controllers/Rewards.php
@@ -1,0 +1,150 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Rewards extends CI_Controller
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->model(['Reward_product_model','Member_model']);
+        $this->load->library(['session','form_validation']);
+        $this->load->helper(['url','form']);
+    }
+
+    private function authorize()
+    {
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+    }
+
+    public function index()
+    {
+        $this->authorize();
+        if ($this->session->userdata('role') !== 'kasir') {
+            show_error('Forbidden', 403);
+        }
+        $data['products'] = $this->Reward_product_model->get_all();
+        $this->load->view('rewards/index', $data);
+    }
+
+    public function member_lookup()
+    {
+        $this->authorize();
+        if ($this->session->userdata('role') !== 'kasir') {
+            show_error('Forbidden', 403);
+        }
+        $kode = $this->input->post('kode_member', TRUE);
+        $member = $this->Member_model->get_by_kode($kode);
+        if ($member) {
+            $this->output
+                ->set_content_type('application/json')
+                ->set_output(json_encode(['status' => 'ok', 'member' => $member]));
+        } else {
+            $this->output
+                ->set_content_type('application/json')
+                ->set_output(json_encode(['status' => 'error', 'message' => 'Member tidak ditemukan']));
+        }
+    }
+
+    public function redeem($id)
+    {
+        $this->authorize();
+        if ($this->session->userdata('role') !== 'kasir') {
+            show_error('Forbidden', 403);
+        }
+        $kode = $this->input->post('kode_member', TRUE);
+        $member = $this->Member_model->get_by_kode($kode);
+        if (!$member) {
+            $this->output
+                ->set_content_type('application/json')
+                ->set_output(json_encode(['status' => 'error', 'message' => 'Member tidak ditemukan']));
+            return;
+        }
+        $product = $this->Reward_product_model->get_by_id($id);
+        if (!$product) {
+            $this->output
+                ->set_content_type('application/json')
+                ->set_output(json_encode(['status' => 'error', 'message' => 'Produk tidak ditemukan']));
+            return;
+        }
+        if ($product->stok <= 0) {
+            $this->output
+                ->set_content_type('application/json')
+                ->set_output(json_encode(['status' => 'error', 'message' => 'Maaf, stok hadiah ini sudah habis.']));
+            return;
+        }
+        if ($member->poin < $product->poin) {
+            $this->output
+                ->set_content_type('application/json')
+                ->set_output(json_encode(['status' => 'error', 'message' => 'Maaf, poin member tidak mencukupi untuk menukar hadiah ini.']));
+            return;
+        }
+        $this->Member_model->deduct_points($member->id, $product->poin);
+        $this->Reward_product_model->reduce_stock($id, 1);
+        $this->Reward_product_model->log_redemption($member->id, $id);
+        $updated_member = $this->Member_model->get_by_kode($kode);
+        $updated_product = $this->Reward_product_model->get_by_id($id);
+        $this->output
+            ->set_content_type('application/json')
+            ->set_output(json_encode([
+                'status' => 'ok',
+                'poin'   => $updated_member ? $updated_member->poin : 0,
+                'stok'   => $updated_product ? $updated_product->stok : 0
+            ]));
+    }
+
+    public function create()
+    {
+        $this->authorize();
+        if ($this->session->userdata('role') !== 'owner') {
+            show_error('Forbidden', 403);
+        }
+        $this->load->view('rewards/create');
+    }
+
+    public function store()
+    {
+        $this->authorize();
+        if ($this->session->userdata('role') !== 'owner') {
+            show_error('Forbidden', 403);
+        }
+        $this->form_validation->set_rules('nama_produk', 'Nama Produk', 'required');
+        $this->form_validation->set_rules('poin', 'Poin', 'required|integer');
+        $this->form_validation->set_rules('stok', 'Stok', 'required|integer');
+        if ($this->form_validation->run() === TRUE) {
+            $data = [
+                'nama_produk' => $this->input->post('nama_produk', TRUE),
+                'poin'        => $this->input->post('poin', TRUE),
+                'stok'        => $this->input->post('stok', TRUE)
+            ];
+            $this->Reward_product_model->insert($data);
+            $this->session->set_flashdata('success', 'Produk ditambahkan.');
+            redirect('rewards/manage');
+            return;
+        }
+        $this->create();
+    }
+
+    public function delete($id)
+    {
+        $this->authorize();
+        if ($this->session->userdata('role') !== 'owner') {
+            show_error('Forbidden', 403);
+        }
+        $this->Reward_product_model->delete($id);
+        $this->session->set_flashdata('success', 'Produk dihapus.');
+        redirect('rewards/manage');
+    }
+
+    public function manage()
+    {
+        $this->authorize();
+        if ($this->session->userdata('role') !== 'owner') {
+            show_error('Forbidden', 403);
+        }
+        $data['products'] = $this->Reward_product_model->get_all();
+        $this->load->view('rewards/manage', $data);
+    }
+}
+?>

--- a/application/models/Booking_model.php
+++ b/application/models/Booking_model.php
@@ -115,6 +115,9 @@ class Booking_model extends CI_Model
     public function insert($data)
     {
         $data['booking_code'] = $this->generate_booking_code();
+        if (!isset($data['poin_member'])) {
+            $data['poin_member'] = 0;
+        }
         $this->db->insert($this->table, $data);
         return $this->db->insert_id();
     }
@@ -193,5 +196,10 @@ class Booking_model extends CI_Model
     public function update($id, $data)
     {
         return $this->db->where('id', $id)->update($this->table, $data);
+    }
+
+    public function get_by_id($id)
+    {
+        return $this->db->get_where($this->table, ['id' => $id])->row();
     }
 }

--- a/application/models/Point_rule_model.php
+++ b/application/models/Point_rule_model.php
@@ -1,0 +1,27 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Point_rule_model extends CI_Model
+{
+    protected $table = 'point_rules';
+
+    public function get()
+    {
+        return $this->db->get($this->table)->row();
+    }
+
+    public function update($product_rate, $booking_rate)
+    {
+        $data = [
+            'product_rate' => (int)$product_rate,
+            'booking_rate' => (int)$booking_rate
+        ];
+        $exists = $this->db->get($this->table)->row();
+        if ($exists) {
+            $this->db->update($this->table, $data, ['id' => $exists->id]);
+        } else {
+            $this->db->insert($this->table, $data);
+        }
+    }
+}
+?>

--- a/application/models/Reward_product_model.php
+++ b/application/models/Reward_product_model.php
@@ -1,0 +1,46 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Reward_product_model extends CI_Model
+{
+    protected $table = 'reward_products';
+    protected $log_table = 'reward_redemptions';
+
+    public function get_all()
+    {
+        return $this->db->get($this->table)->result();
+    }
+
+    public function get_by_id($id)
+    {
+        return $this->db->get_where($this->table, ['id' => $id])->row();
+    }
+
+    public function insert($data)
+    {
+        $this->db->insert($this->table, $data);
+        return $this->db->insert_id();
+    }
+
+    public function delete($id)
+    {
+        $this->db->where('id', $id)->delete($this->table);
+    }
+
+    public function reduce_stock($id, $qty = 1)
+    {
+        $this->db->set('stok', 'stok - ' . (int)$qty, false)
+                 ->where('id', $id)
+                 ->where('stok >=', $qty)
+                 ->update($this->table);
+    }
+
+    public function log_redemption($user_id, $reward_id)
+    {
+        $this->db->insert($this->log_table, [
+            'user_id'   => $user_id,
+            'reward_id' => $reward_id
+        ]);
+    }
+}
+?>

--- a/application/models/Sale_model.php
+++ b/application/models/Sale_model.php
@@ -14,7 +14,8 @@ class Sale_model extends CI_Model
             'id_kasir'      => $data['id_kasir'],
             'customer_id'   => isset($data['customer_id']) ? $data['customer_id'] : null,
             'nomor_nota'    => $data['nomor_nota'],
-            'total_belanja' => $data['total_belanja']
+            'total_belanja' => $data['total_belanja'],
+            'poin_member'   => isset($data['poin_member']) ? $data['poin_member'] : 0
         ];
 
         $this->db->insert($this->table, $insertData);

--- a/application/views/members/card.php
+++ b/application/views/members/card.php
@@ -1,10 +1,11 @@
 <?php $this->load->view('templates/header'); ?>
-<h2>Member Card</h2>
-<div class="card mx-auto" style="width: 18rem;">
-    <img src="<?php echo base_url('uploads/default-profile.svg'); ?>" class="card-img-top" alt="Profile Icon">
-    <div class="card-body text-center">
+<h2>Kartu Member</h2>
+<div class="card mx-auto text-center" style="width:18rem;background:linear-gradient(135deg,#00b4d8,#90e0ef);color:#fff;">
+    <img src="<?php echo base_url('uploads/default-profile.svg'); ?>" class="card-img-top p-4" alt="Profile Icon">
+    <div class="card-body">
         <h5 class="card-title"><?php echo htmlspecialchars($member->nama_lengkap); ?></h5>
-        <p class="card-text"><?php echo htmlspecialchars($member->kode_member); ?></p>
+        <p class="card-text mb-1"><?php echo htmlspecialchars($member->kode_member); ?></p>
+        <p class="display-4"><?php echo (int) $member->poin; ?><small class="h6"> pts</small></p>
     </div>
 </div>
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/points/rules.php
+++ b/application/views/points/rules.php
@@ -1,0 +1,21 @@
+<?php $this->load->view('templates/header'); ?>
+<div class="card" style="background-color:#f0f9ff;">
+    <div class="card-body">
+        <h2 class="card-title text-center">Perhitungan Poin</h2>
+        <?php if ($this->session->flashdata('success')): ?>
+            <div class="alert alert-success text-center"><?= $this->session->flashdata('success'); ?></div>
+        <?php endif; ?>
+        <?php echo form_open('points'); ?>
+            <div class="form-group">
+                <label>Rp per 1 poin belanja produk</label>
+                <input type="number" name="product_rate" class="form-control" value="<?= isset($rules->product_rate) ? $rules->product_rate : 200; ?>" min="1" required>
+            </div>
+            <div class="form-group mt-2">
+                <label>Rp per 1 poin sewa lapangan</label>
+                <input type="number" name="booking_rate" class="form-control" value="<?= isset($rules->booking_rate) ? $rules->booking_rate : 100; ?>" min="1" required>
+            </div>
+            <button type="submit" class="btn btn-primary mt-3">Simpan</button>
+        <?php echo form_close(); ?>
+    </div>
+</div>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/rewards/create.php
+++ b/application/views/rewards/create.php
@@ -1,0 +1,18 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Tambah Produk Penukaran</h2>
+<form method="post" action="<?= site_url('rewards/store'); ?>">
+    <div class="form-group">
+        <label>Nama Produk</label>
+        <input type="text" name="nama_produk" class="form-control" required>
+    </div>
+    <div class="form-group">
+        <label>Poin</label>
+        <input type="number" name="poin" class="form-control" required>
+    </div>
+    <div class="form-group">
+        <label>Stok</label>
+        <input type="number" name="stok" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Simpan</button>
+</form>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/rewards/index.php
+++ b/application/views/rewards/index.php
@@ -1,0 +1,117 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Penukaran Poin</h2>
+<div id="message"></div>
+<div class="row mb-4">
+    <div class="col-md-8">
+        <div class="form-row">
+            <div class="form-group col-md-3">
+                <label for="kode_member">Kode Member</label>
+                <input type="text" id="kode_member" class="form-control" placeholder="0000000001">
+            </div>
+            <div class="form-group col-md-3">
+                <label for="nama_member">Nama Member</label>
+                <input type="text" id="nama_member" class="form-control" readonly>
+            </div>
+            <div class="form-group col-md-3">
+                <label for="alamat">Alamat</label>
+                <input type="text" id="alamat" class="form-control" readonly>
+            </div>
+            <div class="form-group col-md-3">
+                <label for="no_hp">No Hp</label>
+                <input type="text" id="no_hp" class="form-control" readonly>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4 text-center">
+        <h4>Sisa Poin</h4>
+        <div id="sisaPoin" class="display-4 text-success">0</div>
+    </div>
+</div>
+<div class="mb-3">
+    <input type="text" id="search" class="form-control" placeholder="Cari hadiah...">
+</div>
+<table class="table table-bordered" id="rewardTable">
+    <thead>
+        <tr>
+            <th>Nama Produk</th>
+            <th>Poin</th>
+            <th>Stock</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($products as $p): ?>
+        <tr data-name="<?= strtolower(htmlspecialchars($p->nama_produk)); ?>">
+            <td><?= htmlspecialchars($p->nama_produk); ?></td>
+            <td class="poin"><?= (int)$p->poin; ?></td>
+            <td class="stok"><?= (int)$p->stok; ?></td>
+            <td><button class="btn btn-primary btn-sm redeem" data-id="<?= $p->id; ?>"><i class="fas fa-exchange-alt"></i></button></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<script>
+(function(){
+    function loadMember(kode){
+        if(!kode) return;
+        fetch('<?= site_url('rewards/member_lookup'); ?>', {
+            method: 'POST',
+            headers: {'Content-Type':'application/x-www-form-urlencoded'},
+            body: 'kode_member=' + encodeURIComponent(kode)
+        }).then(r => r.json()).then(function(res){
+            if(res.status === 'ok'){
+                document.getElementById('nama_member').value = res.member.nama_lengkap;
+                document.getElementById('alamat').value = res.member.alamat;
+                document.getElementById('no_hp').value = res.member.no_telepon;
+                document.getElementById('sisaPoin').textContent = res.member.poin;
+            }else{
+                document.getElementById('nama_member').value = '';
+                document.getElementById('alamat').value = '';
+                document.getElementById('no_hp').value = '';
+                document.getElementById('sisaPoin').textContent = '0';
+                alert(res.message);
+            }
+        });
+    }
+    var kodeInput = document.getElementById('kode_member');
+    kodeInput.addEventListener('keydown', function(e){
+        if(e.key === 'Enter' || e.key === 'Tab'){
+            e.preventDefault();
+            loadMember(kodeInput.value);
+        }
+    });
+    document.getElementById('search').addEventListener('keyup', function(){
+        var q = this.value.toLowerCase();
+        document.querySelectorAll('#rewardTable tbody tr').forEach(function(row){
+            var name = row.getAttribute('data-name');
+            row.style.display = name.indexOf(q) !== -1 ? '' : 'none';
+        });
+    });
+    document.querySelectorAll('#rewardTable .redeem').forEach(function(btn){
+        btn.addEventListener('click', function(){
+            var kode = kodeInput.value;
+            if(!kode){
+                alert('Isi kode member terlebih dahulu.');
+                return;
+            }
+            var id = this.getAttribute('data-id');
+            fetch('<?= site_url('rewards/redeem'); ?>/' + id, {
+                method: 'POST',
+                headers: {'Content-Type':'application/x-www-form-urlencoded'},
+                body: 'kode_member=' + encodeURIComponent(kode)
+            }).then(r => r.json()).then(function(res){
+                var msgDiv = document.getElementById('message');
+                if(res.status === 'ok'){
+                    document.getElementById('sisaPoin').textContent = res.poin;
+                    var row = document.querySelector('#rewardTable button[data-id="'+id+'"]').closest('tr');
+                    row.querySelector('.stok').textContent = res.stok;
+                    msgDiv.innerHTML = '<div class="alert alert-success">Penukaran berhasil!</div>';
+                }else{
+                    msgDiv.innerHTML = '<div class="alert alert-danger">'+res.message+'</div>';
+                }
+            });
+        });
+    });
+})();
+</script>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/rewards/manage.php
+++ b/application/views/rewards/manage.php
@@ -1,0 +1,32 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Kelola Produk Penukaran</h2>
+<?php if ($this->session->flashdata('success')): ?>
+    <div class="alert alert-success"><?= $this->session->flashdata('success'); ?></div>
+<?php endif; ?>
+<?php if ($this->session->flashdata('error')): ?>
+    <div class="alert alert-danger"><?= $this->session->flashdata('error'); ?></div>
+<?php endif; ?>
+<a href="<?= site_url('rewards/create'); ?>" class="btn btn-primary mb-3">Tambah Produk</a>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Produk</th>
+            <th>Poin</th>
+            <th>Stok</th>
+            <th>Aksi</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($products as $p): ?>
+            <tr>
+                <td><?= htmlspecialchars($p->nama_produk); ?></td>
+                <td><?= (int) $p->poin; ?></td>
+                <td><?= (int) $p->stok; ?></td>
+                <td>
+                    <a href="<?= site_url('rewards/delete/'.$p->id); ?>" class="btn btn-danger btn-sm" onclick="return confirm('Hapus produk?');">Hapus</a>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -66,6 +66,9 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
                 <?php if ($role === 'kasir'): ?>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('members'); ?>">Data Member</a></li>
                 <?php endif; ?>
+                <?php if ($role === 'kasir'): ?>
+                    <li class="nav-item"><a class="nav-link" href="<?php echo site_url('rewards'); ?>">Penukaran Poin</a></li>
+                <?php endif; ?>
             <?php endif; ?>
 
             <?php if ($this->session->userdata('logged_in')): ?>
@@ -90,6 +93,8 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
                 <?php if ($role === 'owner'): ?>
                     <a class="dropdown-item" href="<?php echo site_url('users'); ?>">Users</a>
                     <a class="dropdown-item" href="<?php echo site_url('courts'); ?>">Lapangan</a>
+                    <a class="dropdown-item" href="<?php echo site_url('points'); ?>">Perhitungan Poin</a>
+                    <a class="dropdown-item" href="<?php echo site_url('rewards/manage'); ?>">Kelola Hadiah Poin</a>
                 <?php endif; ?>
 
             </div>

--- a/database.sql
+++ b/database.sql
@@ -40,6 +40,7 @@ CREATE TABLE `bookings` (
   `harga_booking` decimal(10,2) NOT NULL,
   `diskon` decimal(10,2) NOT NULL,
   `total_harga` decimal(10,2) NOT NULL,
+  `poin_member` int(11) NOT NULL DEFAULT 0,
   `status_booking` enum('pending','confirmed','batal','selesai') DEFAULT 'pending',
   `keterangan` text,
   `bukti_pembayaran` varchar(255) DEFAULT NULL,
@@ -51,13 +52,13 @@ CREATE TABLE `bookings` (
 -- Dumping data for table `bookings`
 --
 
-INSERT INTO `bookings` (`id`, `booking_code`, `id_user`, `id_court`, `tanggal_booking`, `jam_mulai`, `jam_selesai`, `durasi`, `harga_booking`, `diskon`, `total_harga`, `status_booking`, `keterangan`, `bukti_pembayaran`, `status_pembayaran`, `created_at`) VALUES
-(1, '250826-0001', 1, 1, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 01:59:44'),
-(2, '250826-0002', 1, 1, '2025-08-27', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:00:29'),
-(3, '250825-0001', 3, 2, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, NULL, 'belum_bayar', '2025-08-25 02:27:04'),
-(4, '250825-0002', 3, 3, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'batal', '', NULL, 'belum_bayar', '2025-08-25 02:33:16'),
-(5, '250826-0003', 1, 1, '2025-08-25', '14:00:00', '15:00:00', 60, '300000.00', '0.00', '300000.00', 'batal', '', NULL, 'belum_bayar', '2025-08-26 02:38:42'),
-(6, '250826-0004', 1, 2, '2025-08-24', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:39:50');
+INSERT INTO `bookings` (`id`, `booking_code`, `id_user`, `id_court`, `tanggal_booking`, `jam_mulai`, `jam_selesai`, `durasi`, `harga_booking`, `diskon`, `total_harga`, `poin_member`, `status_booking`, `keterangan`, `bukti_pembayaran`, `status_pembayaran`, `created_at`) VALUES
+(1, '250826-0001', 1, 1, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 01:59:44'),
+(2, '250826-0002', 1, 1, '2025-08-27', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:00:29'),
+(3, '250825-0001', 3, 2, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-25 02:27:04'),
+(4, '250825-0002', 3, 3, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'batal', '', NULL, 'belum_bayar', '2025-08-25 02:33:16'),
+(5, '250826-0003', 1, 1, '2025-08-25', '14:00:00', '15:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'batal', '', NULL, 'belum_bayar', '2025-08-26 02:38:42'),
+(6, '250826-0004', 1, 2, '2025-08-24', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:39:50');
 
 -- --------------------------------------------------------
 
@@ -111,15 +112,16 @@ CREATE TABLE `member_data` (
   `alamat` varchar(255) NOT NULL,
   `kecamatan` varchar(100) NOT NULL,
   `kota` varchar(100) NOT NULL,
-  `provinsi` varchar(100) NOT NULL
+  `provinsi` varchar(100) NOT NULL,
+  `poin` int(11) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 --
 -- Dumping data for table `member_data`
 --
 
-INSERT INTO `member_data` (`id`, `user_id`, `kode_member`, `alamat`, `kecamatan`, `kota`, `provinsi`) VALUES
-(2, 9, '0000000009', 'kemiriamba rt 001 rw 001 no 22', 'Jatibarang', 'Kab. Brebes', 'Jawa Tengah');
+INSERT INTO `member_data` (`id`, `user_id`, `kode_member`, `alamat`, `kecamatan`, `kota`, `provinsi`, `poin`) VALUES
+(2, 9, '0000000009', 'kemiriamba rt 001 rw 001 no 22', 'Jatibarang', 'Kab. Brebes', 'Jawa Tengah', 0);
 
 -- --------------------------------------------------------
 
@@ -179,8 +181,10 @@ INSERT INTO `products` (`id`, `nama_produk`, `harga_jual`, `stok`, `kategori`, `
 CREATE TABLE `sales` (
   `id` int(11) NOT NULL,
   `id_kasir` int(11) NOT NULL,
+  `customer_id` int(11) DEFAULT NULL,
   `nomor_nota` varchar(50) NOT NULL,
   `total_belanja` decimal(10,2) NOT NULL,
+  `poin_member` int(11) NOT NULL DEFAULT 0,
   `tanggal_transaksi` datetime DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
@@ -188,8 +192,8 @@ CREATE TABLE `sales` (
 -- Dumping data for table `sales`
 --
 
-INSERT INTO `sales` (`id`, `id_kasir`, `nomor_nota`, `total_belanja`, `tanggal_transaksi`) VALUES
-(1, 1, 'INV-1756190933', '25000.00', '2025-08-26 13:48:53');
+INSERT INTO `sales` (`id`, `id_kasir`, `customer_id`, `nomor_nota`, `total_belanja`, `poin_member`, `tanggal_transaksi`) VALUES
+(1, 1, NULL, 'INV-1756190933', '25000.00', 0, '2025-08-26 13:48:53');
 
 -- --------------------------------------------------------
 
@@ -213,6 +217,51 @@ INSERT INTO `sale_details` (`id`, `id_sale`, `id_product`, `jumlah`, `subtotal`)
 (1, 1, 1, 1, '10000.00'),
 (2, 1, 2, 1, '10000.00'),
 (3, 1, 3, 1, '5000.00');
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `reward_products`
+--
+
+CREATE TABLE `reward_products` (
+  `id` int(11) NOT NULL,
+  `nama_produk` varchar(255) NOT NULL,
+  `poin` int(11) NOT NULL,
+  `stok` int(11) NOT NULL DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `reward_redemptions`
+--
+
+CREATE TABLE `reward_redemptions` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  `reward_id` int(11) NOT NULL,
+  `tanggal` datetime DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `point_rules`
+--
+
+CREATE TABLE `point_rules` (
+  `id` int(11) NOT NULL,
+  `product_rate` int(11) NOT NULL DEFAULT 200,
+  `booking_rate` int(11) NOT NULL DEFAULT 100
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Dumping data for table `point_rules`
+--
+
+INSERT INTO `point_rules` (`id`, `product_rate`, `booking_rate`) VALUES
+(1, 200, 100);
 
 -- --------------------------------------------------------
 
@@ -293,6 +342,24 @@ ALTER TABLE `courts`
 ALTER TABLE `member_data`
   ADD PRIMARY KEY (`id`),
   ADD KEY `user_id` (`user_id`);
+
+-- Indexes for table `reward_products`
+--
+ALTER TABLE `reward_products`
+  ADD PRIMARY KEY (`id`);
+
+-- Indexes for table `reward_redemptions`
+--
+ALTER TABLE `reward_redemptions`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `user_id` (`user_id`),
+  ADD KEY `reward_id` (`reward_id`);
+
+--
+-- Indexes for table `point_rules`
+--
+ALTER TABLE `point_rules`
+  ADD PRIMARY KEY (`id`);
 
 --
 -- Indexes for table `payments`
@@ -391,6 +458,24 @@ ALTER TABLE `sale_details`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;
 
 --
+-- AUTO_INCREMENT for table `reward_products`
+--
+ALTER TABLE `reward_products`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `reward_redemptions`
+--
+ALTER TABLE `reward_redemptions`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `point_rules`
+--
+ALTER TABLE `point_rules`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
+
+--
 -- AUTO_INCREMENT for table `store_status`
 --
 ALTER TABLE `store_status`
@@ -426,6 +511,13 @@ ALTER TABLE `payments`
   ADD CONSTRAINT `payments_ibfk_1` FOREIGN KEY (`id_booking`) REFERENCES `bookings` (`id`),
   ADD CONSTRAINT `payments_ibfk_2` FOREIGN KEY (`id_sale`) REFERENCES `sales` (`id`),
   ADD CONSTRAINT `payments_ibfk_3` FOREIGN KEY (`id_kasir`) REFERENCES `users` (`id`);
+
+--
+-- Constraints for table `reward_redemptions`
+--
+ALTER TABLE `reward_redemptions`
+  ADD CONSTRAINT `reward_redemptions_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  ADD CONSTRAINT `reward_redemptions_ibfk_2` FOREIGN KEY (`reward_id`) REFERENCES `reward_products` (`id`);
 
 --
 -- Constraints for table `sales`


### PR DESCRIPTION
## Summary
- Track member points for POS and booking transactions with configurable rules
- Introduce reward product management and point redemption flow
- Display member points and link to redemption menu in the UI
- Award booking points only on cashier confirmation and roll back if booking is cancelled
- Add an owner-only settings page explaining point calculation rules
- Allow owners to update point earnings for product purchases and court rentals
- Limit reward redemption menu to cashiers and provide owner link for managing reward products
- Implement cashier workflow to look up members, validate points and stock, and redeem rewards with live updates

## Testing
- `php -l application/controllers/Booking.php`
- `php -l application/controllers/Points.php`
- `php -l application/controllers/Pos.php`
- `php -l application/models/Point_rule_model.php`
- `php -l application/views/points/rules.php`
- `php -l application/controllers/Rewards.php`
- `php -l application/views/rewards/index.php`
- `php -l application/views/rewards/manage.php`
- `php -l application/views/templates/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc003e5d1c832083969ee56d0533e6