### PR TITLE
Restrict kasir from modifying products

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -228,11 +228,7 @@ class Booking extends CI_Controller
                 $data['bukti_pembayaran'] = $bukti_file;
             }
             $this->Booking_model->insert($data);
-            if ($this->session->userdata('role') === 'kasir') {
-                $this->session->set_flashdata('success', 'Booking berhasil disimpan.');
-            } else {
-                $this->session->set_flashdata('success', 'Booking berhasil disimpan, silakan lakukan pembayaran.');
-            }
+            $this->session->set_flashdata('success', 'booking telah ditambahkan');
             redirect('booking');
             return;
         }

--- a/application/controllers/Products.php
+++ b/application/controllers/Products.php
@@ -23,6 +23,7 @@ class Products extends CI_Controller
         if (!in_array($role, ['kasir','admin_keuangan','owner'])) {
             redirect('dashboard');
         }
+        return $role;
     }
 
     public function index()
@@ -107,7 +108,10 @@ class Products extends CI_Controller
 
     public function edit($id)
     {
-        $this->authorize();
+        $role = $this->authorize();
+        if ($role === 'kasir') {
+            redirect('products');
+        }
         $data['product'] = $this->Product_model->get_by_id($id);
         $data['categories'] = $this->Product_model->get_categories();
         $this->load->view('products/edit', $data);
@@ -115,7 +119,10 @@ class Products extends CI_Controller
 
     public function update($id)
     {
-        $this->authorize();
+        $role = $this->authorize();
+        if ($role === 'kasir') {
+            redirect('products');
+        }
         $this->form_validation->set_rules('nama_produk', 'Nama Produk', 'required');
         $this->form_validation->set_rules('harga_jual', 'Harga Jual', 'required|numeric');
         $this->form_validation->set_rules('stok', 'Stok', 'required|integer');
@@ -138,7 +145,10 @@ class Products extends CI_Controller
 
     public function delete($id)
     {
-        $this->authorize();
+        $role = $this->authorize();
+        if ($role === 'kasir') {
+            redirect('products');
+        }
         $this->Product_model->delete($id);
         $this->session->set_flashdata('success', 'Produk berhasil dihapus.');
         redirect('products');

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -16,6 +16,9 @@ function booking_sort_url($field, $start, $end, $status, $sort, $order)
 }
 ?>
 <h2>Jadwal Booking Lapangan</h2>
+<?php if ($this->session->flashdata('success')): ?>
+    <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
+<?php endif; ?>
 <form method="get" class="form-inline mb-3">
     <label for="start_date" class="mr-2">Dari:</label>
     <input type="date" id="start_date" name="start_date" class="form-control mr-2" value="<?php echo htmlspecialchars($start_date); ?>">

--- a/application/views/products/create.php
+++ b/application/views/products/create.php
@@ -1,7 +1,8 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $role = $this->session->userdata('role'); ?>
 <h2>Tambah Produk</h2>
 <?php echo validation_errors('<div class="alert alert-danger">', '</div>'); ?>
-<form method="post" action="<?php echo site_url('products/store'); ?>">
+<form method="post" action="<?php echo site_url('products/store'); ?>" id="productForm">
     <div class="form-group">
         <label for="nama_produk">Nama Produk</label>
         <input type="text" name="nama_produk" id="nama_produk" class="form-control" value="<?php echo set_value('nama_produk'); ?>" required>
@@ -25,4 +26,35 @@
     <button type="submit" class="btn btn-primary">Simpan</button>
     <a href="<?php echo site_url('products'); ?>" class="btn btn-secondary">Batal</a>
 </form>
+
+<?php if ($role === 'kasir'): ?>
+<!-- Modal Konfirmasi -->
+<div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-body">
+                data tidak bisa diubah dan dihapus, lanjutkan simpan?
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cek Dulu</button>
+                <button type="button" class="btn btn-primary" id="confirmSave">Simpan</button>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+(function() {
+    var form = document.getElementById('productForm');
+    form.addEventListener('submit', function(e) {
+        e.preventDefault();
+        $('#confirmModal').modal('show');
+    });
+    document.getElementById('confirmSave').addEventListener('click', function() {
+        $('#confirmModal').modal('hide');
+        form.submit();
+    });
+})();
+</script>
+<?php endif; ?>
+
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/products/index.php
+++ b/application/views/products/index.php
@@ -3,6 +3,7 @@
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
 <?php endif; ?>
+<?php $role = $this->session->userdata('role'); ?>
 <form method="get" class="form-inline mb-3">
     <input type="date" name="start_date" class="form-control mr-2" value="<?php echo html_escape($start_date); ?>">
     <input type="date" name="end_date" class="form-control mr-2" value="<?php echo html_escape($end_date); ?>">
@@ -27,7 +28,9 @@
             <th>Harga Jual</th>
             <th>Stok</th>
             <th>Kategori</th>
-            <th>Aksi</th>
+            <?php if ($role !== 'kasir'): ?>
+                <th>Aksi</th>
+            <?php endif; ?>
         </tr>
     </thead>
     <tbody>
@@ -38,10 +41,12 @@
             <td><?php echo number_format($product->harga_jual, 0, ',', '.'); ?></td>
             <td><?php echo $product->stok; ?></td>
             <td><?php echo htmlspecialchars($product->kategori); ?></td>
+            <?php if ($role !== 'kasir'): ?>
             <td>
                 <a href="<?php echo site_url('products/edit/'.$product->id); ?>" class="btn btn-sm btn-warning">Edit</a>
                 <a href="<?php echo site_url('products/delete/'.$product->id); ?>" class="btn btn-sm btn-danger" onclick="return confirm('Anda yakin?');">Hapus</a>
             </td>
+            <?php endif; ?>
         </tr>
     <?php endforeach; ?>
     </tbody>


### PR DESCRIPTION
## Summary
- Return user role from authorization helper
- Prevent `kasir` role from accessing product edit, update, or delete endpoints
- Hide edit and delete buttons for `kasir` in product list
- Show confirmation dialog to `kasir` before saving a new product
- Display a success flash message after adding a booking

## Testing
- `php -l application/controllers/Products.php`
- `php -l application/views/products/index.php`
- `php -l application/views/products/create.php`
- `php -l application/controllers/Booking.php`
- `php -l application/views/booking/index.php`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `composer test:coverage` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3e22449883208cfe5d730869f188