### PR TITLE
Restrict kasir from modifying products

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -45,6 +45,8 @@ class Booking extends CI_Controller
         $data['courts']     = $this->Court_model->get_all();
         if ($status === 'pending') {
             $data['bookings'] = $this->Booking_model->get_pending($sort, $order);
+        } elseif ($status === 'confirmed') {
+            $data['bookings'] = $this->Booking_model->get_by_status_and_date_range('confirmed', $start, $end, $sort, $order);
         } else {
             $data['bookings'] = $this->Booking_model->get_by_date_range($start, $end, $sort, $order);
         }
@@ -228,11 +230,7 @@ class Booking extends CI_Controller
                 $data['bukti_pembayaran'] = $bukti_file;
             }
             $this->Booking_model->insert($data);
-            if ($this->session->userdata('role') === 'kasir') {
-                $this->session->set_flashdata('success', 'Booking berhasil disimpan.');
-            } else {
-                $this->session->set_flashdata('success', 'Booking berhasil disimpan, silakan lakukan pembayaran.');
-            }
+            $this->session->set_flashdata('success', 'booking telah ditambahkan');
             redirect('booking');
             return;
         }

--- a/application/controllers/Products.php
+++ b/application/controllers/Products.php
@@ -23,6 +23,7 @@ class Products extends CI_Controller
         if (!in_array($role, ['kasir','admin_keuangan','owner'])) {
             redirect('dashboard');
         }
+        return $role;
     }
 
     public function index()
@@ -107,7 +108,10 @@ class Products extends CI_Controller
 
     public function edit($id)
     {
-        $this->authorize();
+        $role = $this->authorize();
+        if ($role === 'kasir') {
+            redirect('products');
+        }
         $data['product'] = $this->Product_model->get_by_id($id);
         $data['categories'] = $this->Product_model->get_categories();
         $this->load->view('products/edit', $data);
@@ -115,7 +119,10 @@ class Products extends CI_Controller
 
     public function update($id)
     {
-        $this->authorize();
+        $role = $this->authorize();
+        if ($role === 'kasir') {
+            redirect('products');
+        }
         $this->form_validation->set_rules('nama_produk', 'Nama Produk', 'required');
         $this->form_validation->set_rules('harga_jual', 'Harga Jual', 'required|numeric');
         $this->form_validation->set_rules('stok', 'Stok', 'required|integer');
@@ -138,7 +145,10 @@ class Products extends CI_Controller
 
     public function delete($id)
     {
-        $this->authorize();
+        $role = $this->authorize();
+        if ($role === 'kasir') {
+            redirect('products');
+        }
         $this->Product_model->delete($id);
         $this->session->set_flashdata('success', 'Produk berhasil dihapus.');
         redirect('products');

--- a/application/controllers/Rewards.php
+++ b/application/controllers/Rewards.php
@@ -80,10 +80,12 @@ class Rewards extends CI_Controller
                 ->set_output(json_encode(['status' => 'error', 'message' => 'Maaf, poin member tidak mencukupi untuk menukar hadiah ini.']));
             return;
         }
+        $point_awal = $member->poin;
         $this->Member_model->deduct_points($member->id, $product->poin);
         $this->Reward_product_model->reduce_stock($id, 1);
-        $this->Reward_product_model->log_redemption($member->id, $id);
         $updated_member = $this->Member_model->get_by_kode($kode);
+        $point_akhir = $updated_member ? $updated_member->poin : max($point_awal - $product->poin, 0);
+        $this->Reward_product_model->log_redemption($member->id, $id, $point_awal, $point_akhir);
         $updated_product = $this->Reward_product_model->get_by_id($id);
         $this->output
             ->set_content_type('application/json')

--- a/application/models/Booking_model.php
+++ b/application/models/Booking_model.php
@@ -49,6 +49,32 @@ class Booking_model extends CI_Model
                         ->result();
     }
 
+    public function get_by_status_and_date_range($status, $start, $end, $sort = 'jam_mulai', $order = 'asc')
+    {
+        $allowed = [
+            'id_court'       => 'courts.nama_lapangan',
+            'kode_member'    => 'm.kode_member',
+            'tanggal_booking'=> 'bookings.tanggal_booking',
+            'jam_mulai'      => 'bookings.jam_mulai',
+            'jam_selesai'    => 'bookings.jam_selesai',
+            'status_pembayaran' => 'bookings.status_pembayaran',
+            'status_booking' => 'bookings.status_booking',
+            'keterangan'     => 'bookings.keterangan'
+        ];
+        $sort_field = isset($allowed[$sort]) ? $allowed[$sort] : $allowed['jam_mulai'];
+        $order      = strtolower($order) === 'desc' ? 'desc' : 'asc';
+        return $this->db->select('bookings.*, m.kode_member, courts.nama_lapangan')
+                        ->from($this->table)
+                        ->join('member_data m', 'm.user_id = bookings.id_user', 'left')
+                        ->join('courts', 'courts.id = bookings.id_court', 'left')
+                        ->where('bookings.tanggal_booking >=', $start)
+                        ->where('bookings.tanggal_booking <=', $end)
+                        ->where('bookings.status_booking', $status)
+                        ->order_by($sort_field, $order)
+                        ->get()
+                        ->result();
+    }
+
     public function get_by_date_range($start, $end, $sort = 'jam_mulai', $order = 'asc')
     {
         $allowed = [

--- a/application/models/Report_model.php
+++ b/application/models/Report_model.php
@@ -168,7 +168,7 @@ class Report_model extends CI_Model
      */
     public function get_point_exchange_report($start, $end)
     {
-        $this->db->select('m.kode_member, r.tanggal, p.nama_produk, m.poin AS point_akhir, p.poin AS harga_point');
+        $this->db->select('m.kode_member, r.tanggal, p.nama_produk, r.point_awal, r.point_akhir, p.poin AS harga_point');
         $this->db->from('reward_redemptions r');
         $this->db->join('member_data m', 'm.user_id = r.user_id');
         $this->db->join('reward_products p', 'p.id = r.reward_id');
@@ -178,15 +178,13 @@ class Report_model extends CI_Model
 
         $details = [];
         foreach ($rows as $row) {
-            $point_akhir = (int) $row->point_akhir;
-            $harga_point = (int) $row->harga_point;
             $details[] = [
                 'kode_member'  => $row->kode_member,
                 'tanggal'      => date('Y-m-d', strtotime($row->tanggal)),
                 'barang_tukar' => $row->nama_produk,
-                'point_awal'   => $point_akhir + $harga_point,
-                'harga_point'  => $harga_point,
-                'point_akhir'  => $point_akhir,
+                'point_awal'   => (int) $row->point_awal,
+                'harga_point'  => (int) $row->harga_point,
+                'point_akhir'  => (int) $row->point_akhir,
             ];
         }
 

--- a/application/models/Reward_product_model.php
+++ b/application/models/Reward_product_model.php
@@ -35,11 +35,13 @@ class Reward_product_model extends CI_Model
                  ->update($this->table);
     }
 
-    public function log_redemption($user_id, $reward_id)
+    public function log_redemption($user_id, $reward_id, $point_awal, $point_akhir)
     {
         $this->db->insert($this->log_table, [
-            'user_id'   => $user_id,
-            'reward_id' => $reward_id
+            'user_id'     => $user_id,
+            'reward_id'   => $reward_id,
+            'point_awal'  => (int) $point_awal,
+            'point_akhir' => (int) $point_akhir,
         ]);
     }
 }

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -12,10 +12,17 @@ function booking_sort_url($field, $start, $end, $status, $sort, $order)
     if ($status === 'pending') {
         return site_url('booking') . '?status=pending&sort=' . $field . '&order=' . $next;
     }
-    return site_url('booking') . '?start_date=' . urlencode($start) . '&end_date=' . urlencode($end) . '&sort=' . $field . '&order=' . $next;
+    $base = site_url('booking') . '?start_date=' . urlencode($start) . '&end_date=' . urlencode($end);
+    if (!empty($status)) {
+        $base .= '&status=' . urlencode($status);
+    }
+    return $base . '&sort=' . $field . '&order=' . $next;
 }
 ?>
 <h2>Jadwal Booking Lapangan</h2>
+<?php if ($this->session->flashdata('success')): ?>
+    <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
+<?php endif; ?>
 <form method="get" class="form-inline mb-3">
     <label for="start_date" class="mr-2">Dari:</label>
     <input type="date" id="start_date" name="start_date" class="form-control mr-2" value="<?php echo htmlspecialchars($start_date); ?>">
@@ -26,6 +33,9 @@ function booking_sort_url($field, $start, $end, $status, $sort, $order)
         <select id="status" name="status" class="form-control mr-2">
             <option value="">Semua</option>
             <option value="pending" <?php echo $status === 'pending' ? 'selected' : ''; ?>>Pending</option>
+            <?php if ($role === 'kasir'): ?>
+                <option value="confirmed" <?php echo $status === 'confirmed' ? 'selected' : ''; ?>>Confirmed</option>
+            <?php endif; ?>
         </select>
     <?php endif; ?>
     <button type="submit" class="btn btn-primary">Lihat</button>

--- a/application/views/products/create.php
+++ b/application/views/products/create.php
@@ -1,7 +1,8 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $role = $this->session->userdata('role'); ?>
 <h2>Tambah Produk</h2>
 <?php echo validation_errors('<div class="alert alert-danger">', '</div>'); ?>
-<form method="post" action="<?php echo site_url('products/store'); ?>">
+<form method="post" action="<?php echo site_url('products/store'); ?>" id="productForm">
     <div class="form-group">
         <label for="nama_produk">Nama Produk</label>
         <input type="text" name="nama_produk" id="nama_produk" class="form-control" value="<?php echo set_value('nama_produk'); ?>" required>
@@ -25,4 +26,35 @@
     <button type="submit" class="btn btn-primary">Simpan</button>
     <a href="<?php echo site_url('products'); ?>" class="btn btn-secondary">Batal</a>
 </form>
+
+<?php if ($role === 'kasir'): ?>
+<!-- Modal Konfirmasi -->
+<div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-body">
+                data tidak bisa diubah dan dihapus, lanjutkan simpan?
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cek Dulu</button>
+                <button type="button" class="btn btn-primary" id="confirmSave">Simpan</button>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+(function() {
+    var form = document.getElementById('productForm');
+    form.addEventListener('submit', function(e) {
+        e.preventDefault();
+        $('#confirmModal').modal('show');
+    });
+    document.getElementById('confirmSave').addEventListener('click', function() {
+        $('#confirmModal').modal('hide');
+        form.submit();
+    });
+})();
+</script>
+<?php endif; ?>
+
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/products/index.php
+++ b/application/views/products/index.php
@@ -3,6 +3,7 @@
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
 <?php endif; ?>
+<?php $role = $this->session->userdata('role'); ?>
 <form method="get" class="form-inline mb-3">
     <input type="date" name="start_date" class="form-control mr-2" value="<?php echo html_escape($start_date); ?>">
     <input type="date" name="end_date" class="form-control mr-2" value="<?php echo html_escape($end_date); ?>">
@@ -27,7 +28,9 @@
             <th>Harga Jual</th>
             <th>Stok</th>
             <th>Kategori</th>
-            <th>Aksi</th>
+            <?php if ($role !== 'kasir'): ?>
+                <th>Aksi</th>
+            <?php endif; ?>
         </tr>
     </thead>
     <tbody>
@@ -38,10 +41,12 @@
             <td><?php echo number_format($product->harga_jual, 0, ',', '.'); ?></td>
             <td><?php echo $product->stok; ?></td>
             <td><?php echo htmlspecialchars($product->kategori); ?></td>
+            <?php if ($role !== 'kasir'): ?>
             <td>
                 <a href="<?php echo site_url('products/edit/'.$product->id); ?>" class="btn btn-sm btn-warning">Edit</a>
                 <a href="<?php echo site_url('products/delete/'.$product->id); ?>" class="btn btn-sm btn-danger" onclick="return confirm('Anda yakin?');">Hapus</a>
             </td>
+            <?php endif; ?>
         </tr>
     <?php endforeach; ?>
     </tbody>

--- a/database.sql
+++ b/database.sql
@@ -241,6 +241,8 @@ CREATE TABLE `reward_redemptions` (
   `id` int(11) NOT NULL,
   `user_id` int(11) NOT NULL,
   `reward_id` int(11) NOT NULL,
+  `point_awal` int(11) NOT NULL,
+  `point_akhir` int(11) NOT NULL,
   `tanggal` datetime DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 


### PR DESCRIPTION
## Summary
- Return user role from authorization helper
- Prevent `kasir` role from accessing product edit, update, or delete endpoints
- Hide edit and delete buttons for `kasir` in product list
- Show confirmation dialog to `kasir` before saving a new product
- Display a success flash message after adding a booking
- Record starting and ending points for each reward redemption so the point exchange report remains stable
- Let kasir filter booking schedules by confirmed status

## Testing
- `php -l application/controllers/Products.php`
- `php -l application/views/products/index.php`
- `php -l application/views/products/create.php`
- `php -l application/controllers/Booking.php`
- `php -l application/views/booking/index.php`
- `php -l application/controllers/Rewards.php`
- `php -l application/models/Reward_product_model.php`
- `php -l application/models/Report_model.php`
- `php -l application/models/Booking_model.php`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `composer test:coverage` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3e22449883208cfe5d730869f188