### PR TITLE
Restrict kasir from modifying products

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -45,6 +45,8 @@ class Booking extends CI_Controller
         $data['courts']     = $this->Court_model->get_all();
         if ($status === 'pending') {
             $data['bookings'] = $this->Booking_model->get_pending($sort, $order);
+        } elseif ($status === 'confirmed') {
+            $data['bookings'] = $this->Booking_model->get_by_status_and_date_range('confirmed', $start, $end, $sort, $order);
         } else {
             $data['bookings'] = $this->Booking_model->get_by_date_range($start, $end, $sort, $order);
         }
@@ -228,11 +230,7 @@ class Booking extends CI_Controller
                 $data['bukti_pembayaran'] = $bukti_file;
             }
             $this->Booking_model->insert($data);
-            if ($this->session->userdata('role') === 'kasir') {
-                $this->session->set_flashdata('success', 'Booking berhasil disimpan.');
-            } else {
-                $this->session->set_flashdata('success', 'Booking berhasil disimpan, silakan lakukan pembayaran.');
-            }
+            $this->session->set_flashdata('success', 'booking telah ditambahkan');
             redirect('booking');
             return;
         }
@@ -281,7 +279,8 @@ class Booking extends CI_Controller
         $data       = ['status_booking' => $normalized];
         $booking    = $this->Booking_model->get_by_id($id);
         if ($normalized === 'confirmed') {
-            $data['keterangan'] = 'pembayaran sudah di konfirmasi';
+            $data['keterangan']  = 'pembayaran sudah di konfirmasi';
+            $data['confirmed_at'] = date('Y-m-d H:i:s');
             if ($booking && (int) $booking->poin_member === 0) {
                 $rules = $this->Point_rule_model->get();
                 $rate = $rules && (int)$rules->booking_rate > 0 ? (int)$rules->booking_rate : 100;
@@ -299,6 +298,7 @@ class Booking extends CI_Controller
                 $this->Member_model->deduct_points($booking->id_user, (int) $booking->poin_member);
                 $data['poin_member'] = 0;
             }
+            $data['confirmed_at'] = null;
         } elseif ($keterangan !== null) {
             $data['keterangan'] = $keterangan;
         }

--- a/application/controllers/Products.php
+++ b/application/controllers/Products.php
@@ -23,6 +23,7 @@ class Products extends CI_Controller
         if (!in_array($role, ['kasir','admin_keuangan','owner'])) {
             redirect('dashboard');
         }
+        return $role;
     }
 
     public function index()
@@ -107,7 +108,10 @@ class Products extends CI_Controller
 
     public function edit($id)
     {
-        $this->authorize();
+        $role = $this->authorize();
+        if ($role === 'kasir') {
+            redirect('products');
+        }
         $data['product'] = $this->Product_model->get_by_id($id);
         $data['categories'] = $this->Product_model->get_categories();
         $this->load->view('products/edit', $data);
@@ -115,7 +119,10 @@ class Products extends CI_Controller
 
     public function update($id)
     {
-        $this->authorize();
+        $role = $this->authorize();
+        if ($role === 'kasir') {
+            redirect('products');
+        }
         $this->form_validation->set_rules('nama_produk', 'Nama Produk', 'required');
         $this->form_validation->set_rules('harga_jual', 'Harga Jual', 'required|numeric');
         $this->form_validation->set_rules('stok', 'Stok', 'required|integer');
@@ -138,7 +145,10 @@ class Products extends CI_Controller
 
     public function delete($id)
     {
-        $this->authorize();
+        $role = $this->authorize();
+        if ($role === 'kasir') {
+            redirect('products');
+        }
         $this->Product_model->delete($id);
         $this->session->set_flashdata('success', 'Produk berhasil dihapus.');
         redirect('products');

--- a/application/models/Booking_model.php
+++ b/application/models/Booking_model.php
@@ -49,6 +49,32 @@ class Booking_model extends CI_Model
                         ->result();
     }
 
+    public function get_by_status_and_date_range($status, $start, $end, $sort = 'jam_mulai', $order = 'asc')
+    {
+        $allowed = [
+            'id_court'       => 'courts.nama_lapangan',
+            'kode_member'    => 'm.kode_member',
+            'tanggal_booking'=> 'bookings.tanggal_booking',
+            'jam_mulai'      => 'bookings.jam_mulai',
+            'jam_selesai'    => 'bookings.jam_selesai',
+            'status_pembayaran' => 'bookings.status_pembayaran',
+            'status_booking' => 'bookings.status_booking',
+            'keterangan'     => 'bookings.keterangan'
+        ];
+        $sort_field = isset($allowed[$sort]) ? $allowed[$sort] : $allowed['jam_mulai'];
+        $order      = strtolower($order) === 'desc' ? 'desc' : 'asc';
+        return $this->db->select('bookings.*, m.kode_member, courts.nama_lapangan')
+                        ->from($this->table)
+                        ->join('member_data m', 'm.user_id = bookings.id_user', 'left')
+                        ->join('courts', 'courts.id = bookings.id_court', 'left')
+                        ->where('bookings.tanggal_booking >=', $start)
+                        ->where('bookings.tanggal_booking <=', $end)
+                        ->where('bookings.status_booking', $status)
+                        ->order_by($sort_field, $order)
+                        ->get()
+                        ->result();
+    }
+
     public function get_by_date_range($start, $end, $sort = 'jam_mulai', $order = 'asc')
     {
         $allowed = [

--- a/application/models/Member_model.php
+++ b/application/models/Member_model.php
@@ -22,6 +22,10 @@ class Member_model extends CI_Model
             $this->db->like('u.nama_lengkap', $keyword);
             $this->db->or_like('m.kode_member', $keyword);
             $this->db->or_like('u.no_telepon', $keyword);
+            $this->db->or_like('m.alamat', $keyword);
+            $this->db->or_like('m.kecamatan', $keyword);
+            $this->db->or_like('m.kota', $keyword);
+            $this->db->or_like('m.provinsi', $keyword);
             $this->db->group_end();
         }
         if ($limit !== null) {
@@ -41,6 +45,10 @@ class Member_model extends CI_Model
             $this->db->like('u.nama_lengkap', $keyword);
             $this->db->or_like('m.kode_member', $keyword);
             $this->db->or_like('u.no_telepon', $keyword);
+            $this->db->or_like('m.alamat', $keyword);
+            $this->db->or_like('m.kecamatan', $keyword);
+            $this->db->or_like('m.kota', $keyword);
+            $this->db->or_like('m.provinsi', $keyword);
             $this->db->group_end();
         }
         return $this->db->count_all_results();

--- a/application/models/Report_model.php
+++ b/application/models/Report_model.php
@@ -68,15 +68,15 @@ class Report_model extends CI_Model
             ];
         }
         if ($category === 'booking') {
-            $this->db->select('id, booking_code, tanggal_booking, total_harga');
+            $this->db->select('id, booking_code, confirmed_at, total_harga');
             $this->db->from('bookings');
-            $this->db->where('tanggal_booking >=', $start);
-            $this->db->where('tanggal_booking <=', $end);
+            $this->db->where('confirmed_at >=', $start . ' 00:00:00');
+            $this->db->where('confirmed_at <=', $end . ' 23:59:59');
             $this->db->where_in('status_booking', ['confirmed', 'selesai']);
             $rows = $this->db->get()->result();
             foreach ($rows as $b) {
                 $details[] = [
-                    'tanggal'     => $b->tanggal_booking,
+                    'tanggal'     => date('Y-m-d', strtotime($b->confirmed_at)),
                     'keterangan'  => 'Booking #' . $b->booking_code,
                     'uang_masuk'  => (float) $b->total_harga,
                     'uang_keluar' => 0,
@@ -168,7 +168,7 @@ class Report_model extends CI_Model
      */
     public function get_point_exchange_report($start, $end)
     {
-        $this->db->select('m.kode_member, r.tanggal, p.nama_produk, m.poin AS point_akhir, p.poin AS harga_point');
+        $this->db->select('m.kode_member, r.tanggal, p.nama_produk, r.point_awal, r.point_akhir, p.poin AS harga_point');
         $this->db->from('reward_redemptions r');
         $this->db->join('member_data m', 'm.user_id = r.user_id');
         $this->db->join('reward_products p', 'p.id = r.reward_id');
@@ -178,15 +178,13 @@ class Report_model extends CI_Model
 
         $details = [];
         foreach ($rows as $row) {
-            $point_akhir = (int) $row->point_akhir;
-            $harga_point = (int) $row->harga_point;
             $details[] = [
                 'kode_member'  => $row->kode_member,
                 'tanggal'      => date('Y-m-d', strtotime($row->tanggal)),
                 'barang_tukar' => $row->nama_produk,
-                'point_awal'   => $point_akhir + $harga_point,
-                'harga_point'  => $harga_point,
-                'point_akhir'  => $point_akhir,
+                'point_awal'   => (int) $row->point_awal,
+                'harga_point'  => (int) $row->harga_point,
+                'point_akhir'  => (int) $row->point_akhir,
             ];
         }
 

--- a/application/models/Reward_product_model.php
+++ b/application/models/Reward_product_model.php
@@ -35,11 +35,13 @@ class Reward_product_model extends CI_Model
                  ->update($this->table);
     }
 
-    public function log_redemption($user_id, $reward_id)
+    public function log_redemption($user_id, $reward_id, $point_awal, $point_akhir)
     {
         $this->db->insert($this->log_table, [
-            'user_id'   => $user_id,
-            'reward_id' => $reward_id
+            'user_id'     => $user_id,
+            'reward_id'   => $reward_id,
+            'point_awal'  => (int) $point_awal,
+            'point_akhir' => (int) $point_akhir,
         ]);
     }
 }

--- a/application/views/booking/index.php
+++ b/application/views/booking/index.php
@@ -12,10 +12,17 @@ function booking_sort_url($field, $start, $end, $status, $sort, $order)
     if ($status === 'pending') {
         return site_url('booking') . '?status=pending&sort=' . $field . '&order=' . $next;
     }
-    return site_url('booking') . '?start_date=' . urlencode($start) . '&end_date=' . urlencode($end) . '&sort=' . $field . '&order=' . $next;
+    $base = site_url('booking') . '?start_date=' . urlencode($start) . '&end_date=' . urlencode($end);
+    if (!empty($status)) {
+        $base .= '&status=' . urlencode($status);
+    }
+    return $base . '&sort=' . $field . '&order=' . $next;
 }
 ?>
 <h2>Jadwal Booking Lapangan</h2>
+<?php if ($this->session->flashdata('success')): ?>
+    <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
+<?php endif; ?>
 <form method="get" class="form-inline mb-3">
     <label for="start_date" class="mr-2">Dari:</label>
     <input type="date" id="start_date" name="start_date" class="form-control mr-2" value="<?php echo htmlspecialchars($start_date); ?>">
@@ -26,6 +33,9 @@ function booking_sort_url($field, $start, $end, $status, $sort, $order)
         <select id="status" name="status" class="form-control mr-2">
             <option value="">Semua</option>
             <option value="pending" <?php echo $status === 'pending' ? 'selected' : ''; ?>>Pending</option>
+            <?php if ($role === 'kasir'): ?>
+                <option value="confirmed" <?php echo $status === 'confirmed' ? 'selected' : ''; ?>>Confirmed</option>
+            <?php endif; ?>
         </select>
     <?php endif; ?>
     <button type="submit" class="btn btn-primary">Lihat</button>

--- a/application/views/members/index.php
+++ b/application/views/members/index.php
@@ -3,13 +3,15 @@
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
 <?php endif; ?>
-<a href="<?php echo site_url('members/create'); ?>" class="btn btn-primary mb-2">Tambah Member</a>
-<form method="get" class="mb-3" style="max-width:250px;">
-    <input type="text" name="q" class="form-control <?php echo ($search_query && empty($members)) ? 'is-invalid' : ''; ?>" placeholder="Cari member..." value="<?php echo html_escape($search_query); ?>">
-    <div class="invalid-feedback">Member tidak ditemukan</div>
-    <input type="hidden" name="per_page" value="<?php echo $per_page; ?>">
-    <input type="hidden" name="page" value="1">
-</form>
+<div class="d-flex align-items-center mb-3">
+    <a href="<?php echo site_url('members/create'); ?>" class="btn btn-primary mr-2">Tambah Member</a>
+    <form method="get" class="mb-0" style="max-width:250px;">
+        <input type="text" name="q" class="form-control <?php echo ($search_query && empty($members)) ? 'is-invalid' : ''; ?>" placeholder="Cari member..." value="<?php echo html_escape($search_query); ?>">
+        <div class="invalid-feedback">Member tidak ditemukan</div>
+        <input type="hidden" name="per_page" value="<?php echo $per_page; ?>">
+        <input type="hidden" name="page" value="1">
+    </form>
+</div>
 <table id="membersTable" class="table table-bordered">
     <thead>
         <tr>

--- a/application/views/products/create.php
+++ b/application/views/products/create.php
@@ -1,7 +1,8 @@
 <?php $this->load->view('templates/header'); ?>
+<?php $role = $this->session->userdata('role'); ?>
 <h2>Tambah Produk</h2>
 <?php echo validation_errors('<div class="alert alert-danger">', '</div>'); ?>
-<form method="post" action="<?php echo site_url('products/store'); ?>">
+<form method="post" action="<?php echo site_url('products/store'); ?>" id="productForm">
     <div class="form-group">
         <label for="nama_produk">Nama Produk</label>
         <input type="text" name="nama_produk" id="nama_produk" class="form-control" value="<?php echo set_value('nama_produk'); ?>" required>
@@ -25,4 +26,35 @@
     <button type="submit" class="btn btn-primary">Simpan</button>
     <a href="<?php echo site_url('products'); ?>" class="btn btn-secondary">Batal</a>
 </form>
+
+<?php if ($role === 'kasir'): ?>
+<!-- Modal Konfirmasi -->
+<div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-body">
+                data tidak bisa diubah dan dihapus, lanjutkan simpan?
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cek Dulu</button>
+                <button type="button" class="btn btn-primary" id="confirmSave">Simpan</button>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+(function() {
+    var form = document.getElementById('productForm');
+    form.addEventListener('submit', function(e) {
+        e.preventDefault();
+        $('#confirmModal').modal('show');
+    });
+    document.getElementById('confirmSave').addEventListener('click', function() {
+        $('#confirmModal').modal('hide');
+        form.submit();
+    });
+})();
+</script>
+<?php endif; ?>
+
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/products/index.php
+++ b/application/views/products/index.php
@@ -3,6 +3,7 @@
 <?php if ($this->session->flashdata('success')): ?>
     <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
 <?php endif; ?>
+<?php $role = $this->session->userdata('role'); ?>
 <form method="get" class="form-inline mb-3">
     <input type="date" name="start_date" class="form-control mr-2" value="<?php echo html_escape($start_date); ?>">
     <input type="date" name="end_date" class="form-control mr-2" value="<?php echo html_escape($end_date); ?>">
@@ -27,7 +28,9 @@
             <th>Harga Jual</th>
             <th>Stok</th>
             <th>Kategori</th>
-            <th>Aksi</th>
+            <?php if ($role !== 'kasir'): ?>
+                <th>Aksi</th>
+            <?php endif; ?>
         </tr>
     </thead>
     <tbody>
@@ -38,10 +41,12 @@
             <td><?php echo number_format($product->harga_jual, 0, ',', '.'); ?></td>
             <td><?php echo $product->stok; ?></td>
             <td><?php echo htmlspecialchars($product->kategori); ?></td>
+            <?php if ($role !== 'kasir'): ?>
             <td>
                 <a href="<?php echo site_url('products/edit/'.$product->id); ?>" class="btn btn-sm btn-warning">Edit</a>
                 <a href="<?php echo site_url('products/delete/'.$product->id); ?>" class="btn btn-sm btn-danger" onclick="return confirm('Anda yakin?');">Hapus</a>
             </td>
+            <?php endif; ?>
         </tr>
     <?php endforeach; ?>
     </tbody>

--- a/application/views/rewards/catalog.php
+++ b/application/views/rewards/catalog.php
@@ -1,0 +1,20 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Hadiah Poin</h2>
+<div class="row">
+<?php if (!empty($products)): ?>
+    <?php foreach ($products as $p): ?>
+    <div class="col-md-4 mb-4">
+        <div class="card h-100 shadow-sm">
+            <div class="card-body text-center">
+                <h5 class="card-title"><?= htmlspecialchars($p->nama_produk); ?></h5>
+                <p class="card-text"><span class="badge badge-primary"><?= (int)$p->poin; ?> Poin</span></p>
+            </div>
+        </div>
+    </div>
+    <?php endforeach; ?>
+<?php else: ?>
+    <div class="col-12"><div class="alert alert-info">Belum ada hadiah poin tersedia.</div></div>
+<?php endif; ?>
+</div>
+<?php $this->load->view('templates/footer'); ?>
+

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -27,6 +27,7 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
                 <?php $role = $this->session->userdata('role'); ?>
                 <?php if ($role === 'pelanggan'): ?>
                     <li class="nav-item"><a class="nav-link" href="<?php echo site_url('dashboard'); ?>">Dashboard</a></li>
+                    <li class="nav-item"><a class="nav-link" href="<?php echo site_url('rewards/catalog'); ?>">Hadiah Poin</a></li>
                 <?php endif; ?>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="bookingDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Booking</a>

--- a/database.sql
+++ b/database.sql
@@ -45,20 +45,21 @@ CREATE TABLE `bookings` (
   `keterangan` text,
   `bukti_pembayaran` varchar(255) DEFAULT NULL,
   `status_pembayaran` enum('belum_bayar','lunas') DEFAULT 'belum_bayar',
-  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `confirmed_at` datetime DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 --
 -- Dumping data for table `bookings`
 --
 
-INSERT INTO `bookings` (`id`, `booking_code`, `id_user`, `id_court`, `tanggal_booking`, `jam_mulai`, `jam_selesai`, `durasi`, `harga_booking`, `diskon`, `total_harga`, `poin_member`, `status_booking`, `keterangan`, `bukti_pembayaran`, `status_pembayaran`, `created_at`) VALUES
-(1, '250826-0001', 1, 1, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 01:59:44'),
-(2, '250826-0002', 1, 1, '2025-08-27', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:00:29'),
-(3, '250825-0001', 3, 2, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-25 02:27:04'),
-(4, '250825-0002', 3, 3, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'batal', '', NULL, 'belum_bayar', '2025-08-25 02:33:16'),
-(5, '250826-0003', 1, 1, '2025-08-25', '14:00:00', '15:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'batal', '', NULL, 'belum_bayar', '2025-08-26 02:38:42'),
-(6, '250826-0004', 1, 2, '2025-08-24', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:39:50');
+INSERT INTO `bookings` (`id`, `booking_code`, `id_user`, `id_court`, `tanggal_booking`, `jam_mulai`, `jam_selesai`, `durasi`, `harga_booking`, `diskon`, `total_harga`, `poin_member`, `status_booking`, `keterangan`, `bukti_pembayaran`, `status_pembayaran`, `created_at`, `confirmed_at`) VALUES
+(1, '250826-0001', 1, 1, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 01:59:44', NULL),
+(2, '250826-0002', 1, 1, '2025-08-27', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:00:29', NULL),
+(3, '250825-0001', 3, 2, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-25 02:27:04', NULL),
+(4, '250825-0002', 3, 3, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'batal', '', NULL, 'belum_bayar', '2025-08-25 02:33:16', NULL),
+(5, '250826-0003', 1, 1, '2025-08-25', '14:00:00', '15:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'batal', '', NULL, 'belum_bayar', '2025-08-26 02:38:42', NULL),
+(6, '250826-0004', 1, 2, '2025-08-24', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:39:50', NULL);
 
 -- --------------------------------------------------------
 
@@ -241,6 +242,8 @@ CREATE TABLE `reward_redemptions` (
   `id` int(11) NOT NULL,
   `user_id` int(11) NOT NULL,
   `reward_id` int(11) NOT NULL,
+  `point_awal` int(11) NOT NULL,
+  `point_akhir` int(11) NOT NULL,
   `tanggal` datetime DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 


### PR DESCRIPTION
## Summary
- Return user role from authorization helper
- Prevent `kasir` role from accessing product edit, update, or delete endpoints
- Hide edit and delete buttons for `kasir` in product list
- Show confirmation dialog to `kasir` before saving a new product
- Display a success flash message after adding a booking
- Record starting and ending points for each reward redemption so the point exchange report remains stable
- Let kasir filter booking schedules by confirmed status
- Track when a booking is confirmed and use that timestamp in financial reports
- Allow searching members by address on the Data Member page
- Move the "Tambah Member" button beside the search field on the member list
- Add "Hadiah Poin" menu and catalog so customers can browse reward products

## Testing
- `php -l application/controllers/Rewards.php`
- `php -l application/views/templates/header.php`
- `php -l application/views/rewards/catalog.php`
- `composer install --no-interaction` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `composer test:coverage` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3e22449883208cfe5d730869f188