### PR TITLE
Validate unique KTP numbers for members

### DIFF
--- a/application/controllers/Members.php
+++ b/application/controllers/Members.php
@@ -65,7 +65,7 @@ class Members extends CI_Controller
         $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|numeric|min_length[10]|callback_phone_check');
         $this->form_validation->set_rules('password', 'Password', 'required|min_length[6]');
         $this->form_validation->set_rules('tanggal_lahir', 'Tanggal Lahir', 'required');
-        $this->form_validation->set_rules('nomor_ktp', 'Nomor KTP', 'required|numeric|exact_length[16]');
+        $this->form_validation->set_rules('nomor_ktp', 'Nomor KTP', 'required|numeric|exact_length[16]|callback_ktp_check');
         $this->form_validation->set_rules('alamat', 'Alamat', 'required');
         $this->form_validation->set_rules('kecamatan', 'Kecamatan', 'required');
         $this->form_validation->set_rules('kota', 'Kota', 'required');
@@ -111,7 +111,7 @@ class Members extends CI_Controller
         $this->form_validation->set_rules('email', 'Email', 'required|valid_email|callback_email_check['.$id.']');
         $this->form_validation->set_rules('no_telepon', 'No Telepon', 'required|numeric|min_length[10]|callback_phone_check['.$id.']');
         $this->form_validation->set_rules('tanggal_lahir', 'Tanggal Lahir', 'required');
-        $this->form_validation->set_rules('nomor_ktp', 'Nomor KTP', 'required|numeric|exact_length[16]');
+        $this->form_validation->set_rules('nomor_ktp', 'Nomor KTP', 'required|numeric|exact_length[16]|callback_ktp_check['.$id.']');
         $this->form_validation->set_rules('alamat', 'Alamat', 'required');
         $this->form_validation->set_rules('kecamatan', 'Kecamatan', 'required');
         $this->form_validation->set_rules('kota', 'Kota', 'required');
@@ -200,7 +200,7 @@ class Members extends CI_Controller
             $this->form_validation->set_rules('password', 'Password', 'min_length[6]');
         }
         $this->form_validation->set_rules('tanggal_lahir', 'Tanggal Lahir', 'required');
-        $this->form_validation->set_rules('nomor_ktp', 'Nomor KTP', 'required|numeric|exact_length[16]');
+        $this->form_validation->set_rules('nomor_ktp', 'Nomor KTP', 'required|numeric|exact_length[16]|callback_ktp_check['.$id.']');
         $this->form_validation->set_rules('alamat', 'Alamat', 'required');
         $this->form_validation->set_rules('kecamatan', 'Kecamatan', 'required');
         $this->form_validation->set_rules('kota', 'Kota', 'required');
@@ -251,6 +251,15 @@ class Members extends CI_Controller
     {
         if ($this->User_model->phone_exists($no_telepon, $id)) {
             $this->form_validation->set_message('phone_check', 'No telepon sudah digunakan.');
+            return FALSE;
+        }
+        return TRUE;
+    }
+
+    public function ktp_check($nomor_ktp, $id = NULL)
+    {
+        if ($this->Member_model->ktp_exists($nomor_ktp, $id)) {
+            $this->form_validation->set_message('ktp_check', 'Nomor KTP sudah digunakan.');
             return FALSE;
         }
         return TRUE;

--- a/application/models/Member_model.php
+++ b/application/models/Member_model.php
@@ -119,6 +119,15 @@ class Member_model extends CI_Model
         return $this->db->trans_status();
     }
 
+    public function ktp_exists($nomor_ktp, $exclude_user_id = NULL)
+    {
+        $this->db->where('nomor_ktp', $nomor_ktp);
+        if ($exclude_user_id !== NULL) {
+            $this->db->where('user_id !=', $exclude_user_id);
+        }
+        return $this->db->get($this->table)->num_rows() > 0;
+    }
+
     public function add_points($user_id, $points)
     {
         if ($points <= 0) {


### PR DESCRIPTION
## Summary
- Add validation to reject duplicate Nomor KTP when creating or updating members
- Implement `ktp_exists` helper in Member_model and `ktp_check` callback in Members controller

## Testing
- `php -l application/controllers/Members.php`
- `php -l application/models/Member_model.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce4443e58832086c3143198ad9af4