### PR TITLE
Add export and cancellation features for POS and refine financial report

### DIFF
--- a/application/controllers/Pos.php
+++ b/application/controllers/Pos.php
@@ -113,6 +113,45 @@ class Pos extends CI_Controller
         $this->load->view('pos/transactions', $data);
     }
 
+    public function cancelled()
+    {
+        $this->authorize();
+        $start   = $this->input->get('start');
+        $end     = $this->input->get('end');
+        $keyword = $this->input->get('q');
+
+        $per_page = (int) $this->input->get('per_page');
+        $allowed_per_page = [10, 25, 50, 100];
+        if (!in_array($per_page, $allowed_per_page, true)) {
+            $per_page = 10;
+        }
+        $page = max(1, (int) $this->input->get('page'));
+
+        $start_index = ($page - 1) * $per_page;
+        if ($start && $end) {
+            $total_rows = $this->Sale_model->count_filtered($start, $end, $keyword, 'dibatalkan');
+            $sales      = $this->Sale_model->get_paginated($start, $end, $per_page, $start_index, $keyword, 'dibatalkan');
+        } else {
+            $total_rows = 0;
+            $sales = [];
+        }
+
+        $page_total = 0;
+        foreach ($sales as $sale) {
+            $page_total += $sale->total_belanja;
+        }
+
+        $data['filter_start'] = $start;
+        $data['filter_end']   = $end;
+        $data['sales']        = $sales;
+        $data['page_total']   = $page_total;
+        $data['page']         = $page;
+        $data['total_pages']  = (int) ceil($total_rows / $per_page);
+        $data['per_page']     = $per_page;
+        $data['search_query'] = $keyword;
+        $this->load->view('pos/cancelled', $data);
+    }
+
     /**
      * Cetak ulang nota untuk transaksi yang sudah ada.
      */
@@ -130,6 +169,37 @@ class Pos extends CI_Controller
             return;
         }
         $this->print_receipt($id);
+    }
+
+    public function cancel($id)
+    {
+        $this->authorize();
+        if (!is_numeric($id)) {
+            redirect('pos/transactions');
+            return;
+        }
+        $sale = $this->Sale_model->get_by_id($id);
+        if (!$sale || $sale->status === 'dibatalkan') {
+            redirect('pos/transactions');
+            return;
+        }
+        if (date('Y-m-d', strtotime($sale->tanggal_transaksi)) !== date('Y-m-d')) {
+            $this->session->set_flashdata('error', 'Hanya transaksi hari ini yang dapat dibatalkan.');
+            redirect('pos/transactions');
+            return;
+        }
+
+        $details = $this->Sale_detail_model->get_by_sale($id);
+        foreach ($details as $detail) {
+            $this->Product_model->increase_stock($detail->id_product, $detail->jumlah);
+        }
+
+        if ($sale->customer_id && $sale->poin_member > 0) {
+            $this->Member_model->deduct_points($sale->customer_id, $sale->poin_member);
+        }
+
+        $this->Sale_model->cancel($id);
+        redirect('pos/transactions');
     }
     /**
      * Tambah produk ke keranjang.
@@ -279,9 +349,10 @@ class Pos extends CI_Controller
             'id_kasir'       => $this->session->userdata('id')
         ];
         $this->Payment_model->insert($payment);
-        // Kosongkan keranjang
+        // Kosongkan keranjang dan kembali ke halaman POS
         $this->session->unset_userdata('cart');
-        $this->print_receipt($sale_id);
+        $this->session->set_flashdata('success', 'Transaksi berhasil disimpan.');
+        redirect('pos');
     }
 
     private function print_receipt($sale_id)

--- a/application/controllers/Products.php
+++ b/application/controllers/Products.php
@@ -57,6 +57,7 @@ class Products extends CI_Controller
         $data['search_query'] = $keyword;
         $data['categories']   = $categories;
         $data['selected_category'] = $kategori;
+        $data['all_products'] = $this->Product_model->get_all($start_date, $end_date, null, null, $keyword, $kategori);
         $this->load->view('products/index', $data);
     }
 

--- a/application/models/Product_model.php
+++ b/application/models/Product_model.php
@@ -110,4 +110,16 @@ class Product_model extends CI_Model
             $this->db->where('id', $id)->update($this->table, ['stok' => $newStock]);
         }
     }
+
+    /**
+     * Tambah stok produk ketika transaksi dibatalkan.
+     */
+    public function increase_stock($id, $qty)
+    {
+        $product = $this->get_by_id($id);
+        if ($product) {
+            $newStock = $product->stok + $qty;
+            $this->db->where('id', $id)->update($this->table, ['stok' => $newStock]);
+        }
+    }
 }

--- a/application/models/Report_model.php
+++ b/application/models/Report_model.php
@@ -25,6 +25,7 @@ class Report_model extends CI_Model
         $this->db->select_sum('total_belanja', 'total_sales');
         $this->db->where('tanggal_transaksi >=', $start);
         $this->db->where('tanggal_transaksi <=', $end . ' 23:59:59');
+        $this->db->where('status', 'selesai');
         $sales = $this->db->get('sales')->row()->total_sales ?: 0;
 
         return [
@@ -102,6 +103,7 @@ class Report_model extends CI_Model
             $this->db->from('sales');
             $this->db->where('tanggal_transaksi >=', $start);
             $this->db->where('tanggal_transaksi <=', $end . ' 23:59:59');
+            $this->db->where('status', 'selesai');
             $rows = $this->db->get()->result();
             foreach ($rows as $s) {
                 $details[] = [
@@ -199,12 +201,14 @@ class Report_model extends CI_Model
         // Jumlah booking
         $this->db->where('tanggal_booking >=', $start);
         $this->db->where('tanggal_booking <=', $end);
+        $this->db->where('status_booking', 'confirmed');
         $total_bookings = $this->db->count_all_results('bookings');
 
         // Jumlah pelanggan unik
         $this->db->select('id_user');
         $this->db->where('tanggal_booking >=', $start);
         $this->db->where('tanggal_booking <=', $end);
+        $this->db->where('status_booking', 'confirmed');
         $this->db->group_by('id_user');
         $customers = $this->db->get('bookings')->num_rows();
 

--- a/application/models/Sale_model.php
+++ b/application/models/Sale_model.php
@@ -15,7 +15,8 @@ class Sale_model extends CI_Model
             'customer_id'   => isset($data['customer_id']) ? $data['customer_id'] : null,
             'nomor_nota'    => $data['nomor_nota'],
             'total_belanja' => $data['total_belanja'],
-            'poin_member'   => isset($data['poin_member']) ? $data['poin_member'] : 0
+            'poin_member'   => isset($data['poin_member']) ? $data['poin_member'] : 0,
+            'status'        => 'selesai'
         ];
 
         $this->db->insert($this->table, $insertData);
@@ -45,7 +46,7 @@ class Sale_model extends CI_Model
     /**
      * Hitung total baris untuk filter tertentu.
      */
-    public function count_filtered($start_date = null, $end_date = null, $keyword = null)
+    public function count_filtered($start_date = null, $end_date = null, $keyword = null, $status = 'selesai')
     {
         $this->db->from($this->table . ' s');
         $this->db->join('users u', 'u.id = s.customer_id', 'left');
@@ -61,13 +62,14 @@ class Sale_model extends CI_Model
             $this->db->or_like('u.nama_lengkap', $keyword);
             $this->db->group_end();
         }
+        $this->db->where('s.status', $status);
         return $this->db->count_all_results();
     }
 
     /**
      * Ambil data dengan batasan (pagination) untuk mencegah load seluruh dataset.
      */
-    public function get_paginated($start_date = null, $end_date = null, $limit = 10, $offset = 0, $keyword = null)
+    public function get_paginated($start_date = null, $end_date = null, $limit = 10, $offset = 0, $keyword = null, $status = 'selesai')
     {
         $this->db->select('s.*, u.nama_lengkap AS customer_name');
         $this->db->from($this->table . ' s');
@@ -84,8 +86,14 @@ class Sale_model extends CI_Model
             $this->db->or_like('u.nama_lengkap', $keyword);
             $this->db->group_end();
         }
+        $this->db->where('s.status', $status);
         $this->db->order_by('s.tanggal_transaksi', 'DESC');
         $this->db->limit($limit, $offset);
         return $this->db->get()->result();
+    }
+
+    public function cancel($id)
+    {
+        return $this->db->where('id', $id)->update($this->table, ['status' => 'dibatalkan']);
     }
 }

--- a/application/views/pos/cancelled.php
+++ b/application/views/pos/cancelled.php
@@ -1,11 +1,5 @@
 <?php $this->load->view('templates/header'); ?>
-<h2>Daftar Transaksi POS</h2>
-<?php if ($this->session->flashdata('error')): ?>
-    <div class="alert alert-danger"><?php echo $this->session->flashdata('error'); ?></div>
-<?php endif; ?>
-<?php if ($this->session->flashdata('success')): ?>
-    <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
-<?php endif; ?>
+<h2>Laporan Batal Transaksi</h2>
 <form method="get" class="form-inline mb-3">
     <input type="date" name="start" class="form-control mr-2" value="<?php echo set_value('', date('Y-m-d')); ?>">
     <input type="date" name="end" class="form-control mr-2" value="<?php echo set_value('', date('Y-m-d')); ?>">
@@ -30,7 +24,6 @@
                     <th>Customer</th>
                     <th>Total</th>
                     <th>Tanggal</th>
-                    <th>Aksi</th>
                 </tr>
             </thead>
             <tbody>
@@ -40,23 +33,13 @@
                     <td><?php echo htmlspecialchars($s->customer_name ?: 'non member'); ?></td>
                     <td>Rp <?php echo number_format($s->total_belanja, 0, ',', '.'); ?></td>
                     <td><?php echo htmlspecialchars($s->tanggal_transaksi); ?></td>
-                    <td>
-                        <a href="<?php echo site_url('pos/reprint/'.$s->id); ?>" class="btn btn-sm btn-secondary" title="Print nota" aria-label="Print nota"><i class="fas fa-print"></i></a>
-                        <?php $can_cancel = date('Y-m-d', strtotime($s->tanggal_transaksi)) === date('Y-m-d'); ?>
-                        <?php if ($can_cancel): ?>
-                            <a href="<?php echo site_url('pos/cancel/'.$s->id); ?>" class="btn btn-sm btn-secondary" title="Batal" aria-label="Batal" onclick="return confirm('Apakah Anda yakin ingin membatalkan transaksi ini? Tindakan ini tidak dapat dibatalkan.');"><i class="fas fa-times text-white"></i></a>
-                        <?php else: ?>
-                            <button class="btn btn-sm btn-secondary" title="Tidak dapat dibatalkan" disabled><i class="fas fa-times text-white"></i></button>
-                        <?php endif; ?>
-                    </td>
                 </tr>
             <?php endforeach; ?>
             </tbody>
             <tfoot>
                 <tr>
-                    <!-- <th colspan="2" class="text-right">Total Halaman</th> -->
                     <th id="page-total">Rp <?php echo number_format($page_total, 0, ',', '.'); ?></th>
-                    <th colspan="2"></th>
+                    <th colspan="3"></th>
                 </tr>
             </tfoot>
         </table>
@@ -113,9 +96,10 @@
             </form>
         </div>
     <?php else: ?>
-        <p>Tidak ada transaksi pada rentang tanggal tersebut.</p>
+        <p>Tidak ada transaksi batal pada rentang tanggal tersebut.</p>
     <?php endif; ?>
 <?php else: ?>
-    <p>Silakan pilih rentang tanggal untuk melihat transaksi.</p>
+    <p>Silakan pilih rentang tanggal untuk melihat transaksi batal.</p>
 <?php endif; ?>
 <?php $this->load->view('templates/footer'); ?>
+

--- a/application/views/products/index.php
+++ b/application/views/products/index.php
@@ -114,5 +114,53 @@
         </form>
     </div>
 
+<div class="mt-3">
+    <button id="exportPdf" class="btn btn-secondary">Export PDF</button>
+    <button id="exportExcel" class="btn btn-success ml-2">Export Excel</button>
+</div>
+
+<table id="allProductsTable" style="display:none;">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Nama Produk</th>
+            <th>Harga Jual</th>
+            <th>Stok</th>
+            <th>Kategori</th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($all_products as $product): ?>
+        <tr>
+            <td><?php echo $product->id; ?></td>
+            <td><?php echo htmlspecialchars($product->nama_produk); ?></td>
+            <td><?php echo number_format($product->harga_jual, 0, ',', '.'); ?></td>
+            <td><?php echo $product->stok; ?></td>
+            <td><?php echo htmlspecialchars($product->kategori); ?></td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+<script>
+document.getElementById('exportPdf').addEventListener('click', function () {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    doc.text('Daftar Produk', 14, 15);
+    doc.autoTable({ html: '#allProductsTable', startY: 20 });
+    doc.save('daftar_produk.pdf');
+});
+
+document.getElementById('exportExcel').addEventListener('click', function () {
+    const table = document.getElementById('allProductsTable');
+    const wb = XLSX.utils.book_new();
+    const ws = XLSX.utils.table_to_sheet(table);
+    XLSX.utils.book_append_sheet(wb, ws, 'Produk');
+    XLSX.writeFile(wb, 'daftar_produk.xlsx');
+});
+</script>
 
 <?php $this->load->view('templates/footer'); ?>

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -64,6 +64,7 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
                         <div class="dropdown-menu" aria-labelledby="reportDropdown">
                             <a class="dropdown-item" href="<?php echo site_url('finance'); ?>">Laporan Keuangan</a>
                             <a class="dropdown-item" href="<?php echo site_url('point_report'); ?>">Laporan Tukar Poin</a>
+                            <a class="dropdown-item" href="<?php echo site_url('pos/cancelled'); ?>">Laporan Batal Transaksi</a>
                             <?php if ($role === 'owner'): ?>
                                 <a class="dropdown-item" href="<?php echo site_url('reports'); ?>">Laporan Bisnis</a>
                             <?php endif; ?>

--- a/database.sql
+++ b/database.sql
@@ -188,6 +188,7 @@ CREATE TABLE `sales` (
   `nomor_nota` varchar(50) NOT NULL,
   `total_belanja` decimal(10,2) NOT NULL,
   `poin_member` int(11) NOT NULL DEFAULT 0,
+  `status` enum('selesai','dibatalkan') NOT NULL DEFAULT 'selesai',
   `tanggal_transaksi` datetime DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
@@ -195,8 +196,8 @@ CREATE TABLE `sales` (
 -- Dumping data for table `sales`
 --
 
-INSERT INTO `sales` (`id`, `id_kasir`, `customer_id`, `nomor_nota`, `total_belanja`, `poin_member`, `tanggal_transaksi`) VALUES
-(1, 1, NULL, 'INV-1756190933', '25000.00', 0, '2025-08-26 13:48:53');
+INSERT INTO `sales` (`id`, `id_kasir`, `customer_id`, `nomor_nota`, `total_belanja`, `poin_member`, `status`, `tanggal_transaksi`) VALUES
+(1, 1, NULL, 'INV-1756190933', '25000.00', 0, 'selesai', '2025-08-26 13:48:53');
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- allow exporting all products to PDF or Excel
- pass complete product data to view for export buttons
- add cancel action for POS transactions and record status
- restore stock and member points on cancellation and show cancelled report in Laporan menu
- render cancel icon as white and disable it for non-today transactions
- block cancellation endpoint for non-today transactions with a user message
- reset POS cart after successful checkout and return to a clean screen
- count only confirmed bookings in business report summary
- include only completed product sales in financial reports

## Testing
- `php -l application/models/Product_model.php`
- `php -l application/models/Sale_model.php`
- `php -l application/controllers/Products.php`
- `php -l application/views/products/index.php`
- `php -l application/views/pos/cancelled.php`
- `php -l application/views/templates/header.php`
- `php -l application/controllers/Pos.php`
- `php -l application/views/pos/transactions.php`
- `php -l application/models/Report_model.php`


------
https://chatgpt.com/codex/tasks/task_e_68bcf1e1cf0083209bdf99780b2f3736