### PR TITLE
Add member point usage to cashier booking form

### DIFF
--- a/application/models/Point_usage_model.php
+++ b/application/models/Point_usage_model.php
@@ -1,0 +1,25 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Model untuk mencatat penggunaan poin selain penukaran hadiah.
+ */
+class Point_usage_model extends CI_Model
+{
+    protected $table = 'point_usages';
+
+    /**
+     * Simpan log penggunaan poin.
+     */
+    public function log($user_id, $description, $point_awal, $point_used, $point_akhir)
+    {
+        $this->db->insert($this->table, [
+            'user_id'    => $user_id,
+            'description'=> $description,
+            'point_awal' => (int) $point_awal,
+            'point_used' => (int) $point_used,
+            'point_akhir'=> (int) $point_akhir,
+        ]);
+    }
+}
+?>

--- a/application/models/Report_model.php
+++ b/application/models/Report_model.php
@@ -190,6 +190,29 @@ class Report_model extends CI_Model
             ];
         }
 
+        // Log penggunaan poin untuk potongan booking
+        $this->db->select('m.kode_member, u.tanggal, u.description, u.point_awal, u.point_used, u.point_akhir');
+        $this->db->from('point_usages u');
+        $this->db->join('member_data m', 'm.user_id = u.user_id');
+        $this->db->where('u.tanggal >=', $start . ' 00:00:00');
+        $this->db->where('u.tanggal <=', $end . ' 23:59:59');
+        $usage_rows = $this->db->get()->result();
+
+        foreach ($usage_rows as $row) {
+            $details[] = [
+                'kode_member'  => $row->kode_member,
+                'tanggal'      => date('Y-m-d', strtotime($row->tanggal)),
+                'barang_tukar' => $row->description,
+                'point_awal'   => (int) $row->point_awal,
+                'harga_point'  => (int) $row->point_used,
+                'point_akhir'  => (int) $row->point_akhir,
+            ];
+        }
+
+        usort($details, function($a, $b) {
+            return strcmp($a['tanggal'], $b['tanggal']);
+        });
+
         return $details;
     }
 

--- a/database.sql
+++ b/database.sql
@@ -253,6 +253,22 @@ CREATE TABLE `reward_redemptions` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `point_usages`
+--
+
+CREATE TABLE `point_usages` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  `description` varchar(255) NOT NULL,
+  `point_awal` int(11) NOT NULL,
+  `point_used` int(11) NOT NULL,
+  `point_akhir` int(11) NOT NULL,
+  `tanggal` datetime DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `point_rules`
 --
 
@@ -360,6 +376,13 @@ ALTER TABLE `reward_redemptions`
   ADD PRIMARY KEY (`id`),
   ADD KEY `user_id` (`user_id`),
   ADD KEY `reward_id` (`reward_id`);
+
+--
+-- Indexes for table `point_usages`
+--
+ALTER TABLE `point_usages`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `user_id` (`user_id`);
 
 --
 -- Indexes for table `point_rules`
@@ -476,6 +499,12 @@ ALTER TABLE `reward_redemptions`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
 --
+-- AUTO_INCREMENT for table `point_usages`
+--
+ALTER TABLE `point_usages`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT for table `point_rules`
 --
 ALTER TABLE `point_rules`
@@ -524,6 +553,12 @@ ALTER TABLE `payments`
 ALTER TABLE `reward_redemptions`
   ADD CONSTRAINT `reward_redemptions_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
   ADD CONSTRAINT `reward_redemptions_ibfk_2` FOREIGN KEY (`reward_id`) REFERENCES `reward_products` (`id`);
+
+--
+-- Constraints for table `point_usages`
+--
+ALTER TABLE `point_usages`
+  ADD CONSTRAINT `point_usages_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);
 
 --
 -- Constraints for table `sales`


### PR DESCRIPTION
## Summary
- Show member point balance and allow cashiers to apply points on new booking form
- Deduct and log used points during booking creation
- Include point usage in point exchange reports and database schema

## Testing
- `php -l application/models/Point_usage_model.php`
- `php -l application/models/Report_model.php`
- `php -l application/controllers/Booking.php`
- `php -l application/views/booking/create.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd39d0b05c8320888a1131013be3dc