### PR TITLE
Add detail view option to financial report

### DIFF
--- a/application/models/Report_model.php
+++ b/application/models/Report_model.php
@@ -162,6 +162,101 @@ class Report_model extends CI_Model
     }
 
     /**
+     * Mengambil detail transaksi keuangan (booking atau penjualan produk).
+     *
+     * @param string $start    Tanggal awal (YYYY-MM-DD)
+     * @param string $end      Tanggal akhir (YYYY-MM-DD)
+     * @param string $category booking|batal|product|semua
+     * @return array           Detail transaksi dan total uang masuk/keluar
+     */
+    public function get_financial_report_detail($start, $end, $category = 'booking')
+    {
+        $details = [];
+
+        if ($category === 'semua') {
+            $booking = $this->get_financial_report_detail($start, $end, 'booking');
+            $product = $this->get_financial_report_detail($start, $end, 'product');
+            $details = array_merge($booking['details'], $product['details']);
+            usort($details, function ($a, $b) {
+                return strcmp($a['tanggal'], $b['tanggal']);
+            });
+            $total_masuk  = array_sum(array_column($details, 'uang_masuk'));
+            $total_keluar = array_sum(array_column($details, 'uang_keluar'));
+            return [
+                'details'      => $details,
+                'total_masuk'  => $total_masuk,
+                'total_keluar' => $total_keluar,
+                'saldo'        => $total_masuk - $total_keluar,
+            ];
+        }
+
+        if ($category === 'product') {
+            $this->db->select('s.nomor_nota, s.tanggal_transaksi, u.nama_lengkap, m.kode_member, p.nama_produk, p.harga_jual, d.subtotal');
+            $this->db->from('sale_details d');
+            $this->db->join('sales s', 's.id = d.id_sale');
+            $this->db->join('products p', 'p.id = d.id_product');
+            $this->db->join('users u', 'u.id = s.customer_id', 'left');
+            $this->db->join('member_data m', 'm.user_id = u.id', 'left');
+            $this->db->where('s.tanggal_transaksi >=', $start . ' 00:00:00');
+            $this->db->where('s.tanggal_transaksi <=', $end . ' 23:59:59');
+            $this->db->where('s.status', 'selesai');
+            $rows = $this->db->get()->result();
+            foreach ($rows as $r) {
+                $details[] = [
+                    'tanggal'      => date('Y-m-d', strtotime($r->tanggal_transaksi)),
+                    'nomor_nota'   => $r->nomor_nota,
+                    'nama_member'  => $r->nama_lengkap,
+                    'nomor_member' => $r->kode_member,
+                    'nama_produk'  => $r->nama_produk,
+                    'harga_jual'   => (float) $r->harga_jual,
+                    'total_harga'  => (float) $r->subtotal,
+                    'uang_masuk'   => (float) $r->subtotal,
+                    'uang_keluar'  => 0,
+                ];
+            }
+        } else { // booking atau batal
+            $this->db->select('b.booking_code, b.tanggal_booking, b.total_harga, b.poin_member, b.diskon, b.status_booking, u.nama_lengkap, m.kode_member, b.confirmed_at');
+            $this->db->from('bookings b');
+            $this->db->join('users u', 'u.id = b.id_user');
+            $this->db->join('member_data m', 'm.user_id = b.id_user', 'left');
+            $this->db->where('b.confirmed_at >=', $start . ' 00:00:00');
+            $this->db->where('b.confirmed_at <=', $end . ' 23:59:59');
+            if ($category === 'batal') {
+                $this->db->where('b.status_booking', 'batal');
+            } else {
+                $this->db->where_in('b.status_booking', ['confirmed', 'selesai']);
+            }
+            $rows = $this->db->get()->result();
+            foreach ($rows as $r) {
+                $details[] = [
+                    'tanggal'        => $r->tanggal_booking,
+                    'kode_booking'   => $r->booking_code,
+                    'tanggal_booking'=> $r->tanggal_booking,
+                    'nama_member'    => $r->nama_lengkap,
+                    'nomor_member'   => $r->kode_member,
+                    'poin_dipakai'   => (int) $r->poin_member,
+                    'diskon'         => (float) $r->diskon,
+                    'total_harga'    => (float) $r->total_harga,
+                    'uang_masuk'     => ($category === 'batal') ? 0 : (float) $r->total_harga,
+                    'uang_keluar'    => ($category === 'batal') ? (float) $r->total_harga : 0,
+                ];
+            }
+        }
+
+        usort($details, function ($a, $b) {
+            return strcmp($a['tanggal'], $b['tanggal']);
+        });
+        $total_masuk  = array_sum(array_column($details, 'uang_masuk'));
+        $total_keluar = array_sum(array_column($details, 'uang_keluar'));
+        return [
+            'details'      => $details,
+            'total_masuk'  => $total_masuk,
+            'total_keluar' => $total_keluar,
+            'saldo'        => $total_masuk - $total_keluar,
+        ];
+    }
+
+    /**
      * Mengambil riwayat penukaran poin pada rentang tanggal.
      *
      * @param string $start Tanggal awal (YYYY-MM-DD)

--- a/application/views/finance/index.php
+++ b/application/views/finance/index.php
@@ -14,6 +14,11 @@
         <option value="cash_in" <?php echo $category === 'cash_in' ? 'selected' : ''; ?>>Tambah Uang Kas</option>
         <option value="cash_out" <?php echo $category === 'cash_out' ? 'selected' : ''; ?>>Ambil Uang Kas</option>
     </select>
+    <label for="view" class="mr-2">Tampilan:</label>
+    <select name="view" id="view" class="form-control mr-2">
+        <option value="rekap" <?php echo $view_mode === 'rekap' ? 'selected' : ''; ?>>Rekap</option>
+        <option value="detail" <?php echo $view_mode === 'detail' ? 'selected' : ''; ?>>Detail</option>
+    </select>
     <button type="submit" class="btn btn-primary">Tampilkan</button>
     <input type="hidden" name="per_page" value="<?php echo $per_page; ?>">
     <input type="hidden" name="page" value="1">
@@ -25,46 +30,147 @@
     <input type="hidden" name="start_date" value="<?php echo htmlspecialchars($start_date); ?>">
     <input type="hidden" name="end_date" value="<?php echo htmlspecialchars($end_date); ?>">
     <input type="hidden" name="category" value="<?php echo htmlspecialchars($category); ?>">
+    <input type="hidden" name="view" value="<?php echo htmlspecialchars($view_mode); ?>">
     <input type="hidden" name="per_page" value="<?php echo $per_page; ?>">
     <input type="hidden" name="page" value="1">
 </form>
-<table class="table table-bordered" id="financeTable">
-    <thead>
-        <tr>
-            <th>Tanggal</th>
-            <th>Keterangan</th>
-            <th>Uang Masuk</th>
-            <th>Uang Keluar</th>
-        </tr>
-    </thead>
-    <tbody>
-    <?php if (!empty($report['details'])): ?>
-        <?php foreach ($report['details'] as $row): ?>
-        <tr>
-            <td><?php echo htmlspecialchars($row['tanggal']); ?></td>
-            <td><?php echo htmlspecialchars($row['keterangan']); ?></td>
-            <td>Rp <?php echo number_format($row['uang_masuk'], 0, ',', '.'); ?></td>
-            <td>Rp <?php echo number_format($row['uang_keluar'], 0, ',', '.'); ?></td>
-        </tr>
-        <?php endforeach; ?>
+<?php if ($view_mode === 'detail'): ?>
+    <?php if ($category === 'product'): ?>
+    <table class="table table-bordered" id="financeTable">
+        <thead>
+            <tr>
+                <th>Tanggal</th>
+                <th>Nomor Nota</th>
+                <th>Nama Member</th>
+                <th>Nomor Member</th>
+                <th>Nama Produk</th>
+                <th>Harga Jual Produk</th>
+                <th>Total Harga</th>
+                <th>Uang Masuk</th>
+                <th>Uang Keluar</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (!empty($report['details'])): ?>
+            <?php foreach ($report['details'] as $row): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($row['tanggal']); ?></td>
+                <td><?php echo htmlspecialchars($row['nomor_nota']); ?></td>
+                <td><?php echo htmlspecialchars($row['nama_member']); ?></td>
+                <td><?php echo htmlspecialchars($row['nomor_member']); ?></td>
+                <td><?php echo htmlspecialchars($row['nama_produk']); ?></td>
+                <td>Rp <?php echo number_format($row['harga_jual'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['total_harga'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['uang_masuk'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['uang_keluar'], 0, ',', '.'); ?></td>
+            </tr>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <tr>
+                <td colspan="9" class="text-center">Tidak ada data</td>
+            </tr>
+        <?php endif; ?>
+        </tbody>
+        <tfoot>
+            <tr>
+                <th colspan="7">Total</th>
+                <th>Rp <?php echo number_format($report['total_masuk'], 0, ',', '.'); ?></th>
+                <th>Rp <?php echo number_format($report['total_keluar'], 0, ',', '.'); ?></th>
+            </tr>
+            <tr>
+                <th colspan="7">Saldo</th>
+                <th colspan="2">Rp <?php echo number_format($report['saldo'], 0, ',', '.'); ?></th>
+            </tr>
+        </tfoot>
+    </table>
     <?php else: ?>
-        <tr>
-            <td colspan="4" class="text-center">Tidak ada data</td>
-        </tr>
+    <table class="table table-bordered" id="financeTable">
+        <thead>
+            <tr>
+                <th>Kode Booking</th>
+                <th>Tanggal Booking</th>
+                <th>Nama Member</th>
+                <th>Nomor Member</th>
+                <th>Poin Dipakai</th>
+                <th>Diskon</th>
+                <th>Total Harga</th>
+                <th>Uang Masuk</th>
+                <th>Uang Keluar</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (!empty($report['details'])): ?>
+            <?php foreach ($report['details'] as $row): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($row['kode_booking']); ?></td>
+                <td><?php echo htmlspecialchars($row['tanggal_booking']); ?></td>
+                <td><?php echo htmlspecialchars($row['nama_member']); ?></td>
+                <td><?php echo htmlspecialchars($row['nomor_member']); ?></td>
+                <td><?php echo (int) $row['poin_dipakai']; ?></td>
+                <td>Rp <?php echo number_format($row['diskon'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['total_harga'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['uang_masuk'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['uang_keluar'], 0, ',', '.'); ?></td>
+            </tr>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <tr>
+                <td colspan="9" class="text-center">Tidak ada data</td>
+            </tr>
+        <?php endif; ?>
+        </tbody>
+        <tfoot>
+            <tr>
+                <th colspan="7">Total</th>
+                <th>Rp <?php echo number_format($report['total_masuk'], 0, ',', '.'); ?></th>
+                <th>Rp <?php echo number_format($report['total_keluar'], 0, ',', '.'); ?></th>
+            </tr>
+            <tr>
+                <th colspan="7">Saldo</th>
+                <th colspan="2">Rp <?php echo number_format($report['saldo'], 0, ',', '.'); ?></th>
+            </tr>
+        </tfoot>
+    </table>
     <?php endif; ?>
-    </tbody>
-    <tfoot>
-        <tr>
-            <th colspan="2">Total</th>
-            <th>Rp <?php echo number_format($report['total_masuk'], 0, ',', '.'); ?></th>
-            <th>Rp <?php echo number_format($report['total_keluar'], 0, ',', '.'); ?></th>
-        </tr>
-        <tr>
-            <th colspan="2">Saldo</th>
-            <th colspan="2">Rp <?php echo number_format($report['saldo'], 0, ',', '.'); ?></th>
-        </tr>
-    </tfoot>
-</table>
+<?php else: ?>
+    <table class="table table-bordered" id="financeTable">
+        <thead>
+            <tr>
+                <th>Tanggal</th>
+                <th>Keterangan</th>
+                <th>Uang Masuk</th>
+                <th>Uang Keluar</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (!empty($report['details'])): ?>
+            <?php foreach ($report['details'] as $row): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($row['tanggal']); ?></td>
+                <td><?php echo htmlspecialchars($row['keterangan']); ?></td>
+                <td>Rp <?php echo number_format($row['uang_masuk'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['uang_keluar'], 0, ',', '.'); ?></td>
+            </tr>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <tr>
+                <td colspan="4" class="text-center">Tidak ada data</td>
+            </tr>
+        <?php endif; ?>
+        </tbody>
+        <tfoot>
+            <tr>
+                <th colspan="2">Total</th>
+                <th>Rp <?php echo number_format($report['total_masuk'], 0, ',', '.'); ?></th>
+                <th>Rp <?php echo number_format($report['total_keluar'], 0, ',', '.'); ?></th>
+            </tr>
+            <tr>
+                <th colspan="2">Saldo</th>
+                <th colspan="2">Rp <?php echo number_format($report['saldo'], 0, ',', '.'); ?></th>
+            </tr>
+        </tfoot>
+    </table>
+<?php endif; ?>
 <div class="d-flex align-items-center">
     <?php if ($total_pages > 1): ?>
     <?php
@@ -73,7 +179,8 @@
             'end_date'   => $end_date,
             'category'   => $category,
             'per_page'   => $per_page,
-            'q'          => $search
+            'q'          => $search,
+            'view'       => $view_mode
         ];
         $max_links  = 5;
         $start_page = max(1, $page - intdiv($max_links, 2));
@@ -115,6 +222,7 @@
         <input type="hidden" name="start_date" value="<?php echo htmlspecialchars($start_date); ?>">
         <input type="hidden" name="end_date" value="<?php echo htmlspecialchars($end_date); ?>">
         <input type="hidden" name="category" value="<?php echo htmlspecialchars($category); ?>">
+        <input type="hidden" name="view" value="<?php echo htmlspecialchars($view_mode); ?>">
         <input type="hidden" name="q" value="<?php echo htmlspecialchars($search); ?>">
         <input type="hidden" name="page" value="1">
     </form>
@@ -124,37 +232,125 @@
     <button id="exportExcel" class="btn btn-success ml-2">Export Excel</button>
 </div>
 
-<table id="allFinanceTable" style="display:none;">
-    <thead>
-        <tr>
-            <th>Tanggal</th>
-            <th>Keterangan</th>
-            <th>Uang Masuk</th>
-            <th>Uang Keluar</th>
-        </tr>
-    </thead>
-    <tbody>
-    <?php foreach ($all_details as $row): ?>
-        <tr>
-            <td><?php echo htmlspecialchars($row['tanggal']); ?></td>
-            <td><?php echo htmlspecialchars($row['keterangan']); ?></td>
-            <td>Rp <?php echo number_format($row['uang_masuk'], 0, ',', '.'); ?></td>
-            <td>Rp <?php echo number_format($row['uang_keluar'], 0, ',', '.'); ?></td>
-        </tr>
-    <?php endforeach; ?>
-    </tbody>
-    <tfoot>
-        <tr>
-            <th colspan="2">Total</th>
-            <th>Rp <?php echo number_format($report['total_masuk'], 0, ',', '.'); ?></th>
-            <th>Rp <?php echo number_format($report['total_keluar'], 0, ',', '.'); ?></th>
-        </tr>
-        <tr>
-            <th colspan="2">Saldo</th>
-            <th colspan="2">Rp <?php echo number_format($report['saldo'], 0, ',', '.'); ?></th>
-        </tr>
-    </tfoot>
-</table>
+<?php if ($view_mode === 'detail'): ?>
+    <?php if ($category === 'product'): ?>
+    <table id="allFinanceTable" style="display:none;">
+        <thead>
+            <tr>
+                <th>Tanggal</th>
+                <th>Nomor Nota</th>
+                <th>Nama Member</th>
+                <th>Nomor Member</th>
+                <th>Nama Produk</th>
+                <th>Harga Jual Produk</th>
+                <th>Total Harga</th>
+                <th>Uang Masuk</th>
+                <th>Uang Keluar</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($all_details as $row): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($row['tanggal']); ?></td>
+                <td><?php echo htmlspecialchars($row['nomor_nota']); ?></td>
+                <td><?php echo htmlspecialchars($row['nama_member']); ?></td>
+                <td><?php echo htmlspecialchars($row['nomor_member']); ?></td>
+                <td><?php echo htmlspecialchars($row['nama_produk']); ?></td>
+                <td>Rp <?php echo number_format($row['harga_jual'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['total_harga'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['uang_masuk'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['uang_keluar'], 0, ',', '.'); ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+        <tfoot>
+            <tr>
+                <th colspan="7">Total</th>
+                <th>Rp <?php echo number_format($report['total_masuk'], 0, ',', '.'); ?></th>
+                <th>Rp <?php echo number_format($report['total_keluar'], 0, ',', '.'); ?></th>
+            </tr>
+            <tr>
+                <th colspan="7">Saldo</th>
+                <th colspan="2">Rp <?php echo number_format($report['saldo'], 0, ',', '.'); ?></th>
+            </tr>
+        </tfoot>
+    </table>
+    <?php else: ?>
+    <table id="allFinanceTable" style="display:none;">
+        <thead>
+            <tr>
+                <th>Kode Booking</th>
+                <th>Tanggal Booking</th>
+                <th>Nama Member</th>
+                <th>Nomor Member</th>
+                <th>Poin Dipakai</th>
+                <th>Diskon</th>
+                <th>Total Harga</th>
+                <th>Uang Masuk</th>
+                <th>Uang Keluar</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($all_details as $row): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($row['kode_booking']); ?></td>
+                <td><?php echo htmlspecialchars($row['tanggal_booking']); ?></td>
+                <td><?php echo htmlspecialchars($row['nama_member']); ?></td>
+                <td><?php echo htmlspecialchars($row['nomor_member']); ?></td>
+                <td><?php echo (int) $row['poin_dipakai']; ?></td>
+                <td>Rp <?php echo number_format($row['diskon'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['total_harga'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['uang_masuk'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['uang_keluar'], 0, ',', '.'); ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+        <tfoot>
+            <tr>
+                <th colspan="7">Total</th>
+                <th>Rp <?php echo number_format($report['total_masuk'], 0, ',', '.'); ?></th>
+                <th>Rp <?php echo number_format($report['total_keluar'], 0, ',', '.'); ?></th>
+            </tr>
+            <tr>
+                <th colspan="7">Saldo</th>
+                <th colspan="2">Rp <?php echo number_format($report['saldo'], 0, ',', '.'); ?></th>
+            </tr>
+        </tfoot>
+    </table>
+    <?php endif; ?>
+<?php else: ?>
+    <table id="allFinanceTable" style="display:none;">
+        <thead>
+            <tr>
+                <th>Tanggal</th>
+                <th>Keterangan</th>
+                <th>Uang Masuk</th>
+                <th>Uang Keluar</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($all_details as $row): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($row['tanggal']); ?></td>
+                <td><?php echo htmlspecialchars($row['keterangan']); ?></td>
+                <td>Rp <?php echo number_format($row['uang_masuk'], 0, ',', '.'); ?></td>
+                <td>Rp <?php echo number_format($row['uang_keluar'], 0, ',', '.'); ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+        <tfoot>
+            <tr>
+                <th colspan="2">Total</th>
+                <th>Rp <?php echo number_format($report['total_masuk'], 0, ',', '.'); ?></th>
+                <th>Rp <?php echo number_format($report['total_keluar'], 0, ',', '.'); ?></th>
+            </tr>
+            <tr>
+                <th colspan="2">Saldo</th>
+                <th colspan="2">Rp <?php echo number_format($report['saldo'], 0, ',', '.'); ?></th>
+            </tr>
+        </tfoot>
+    </table>
+<?php endif; ?>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js"></script>


### PR DESCRIPTION
## Summary
- Add `Tampilan` dropdown to switch between Rekap and Detail views
- Provide detailed financial report data for bookings and product sales
- Update controller and model to handle new view and search filtering

## Testing
- `php -l application/models/Report_model.php`
- `php -l application/controllers/Finance.php`
- `php -l application/views/finance/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd40458da4832080f299ff06e66f5d