### PR TITLE
Add stock opname feature for admin

### DIFF
--- a/application/controllers/Stock_opname.php
+++ b/application/controllers/Stock_opname.php
@@ -1,0 +1,86 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Controller untuk proses stock opname produk.
+ */
+class Stock_opname extends CI_Controller
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->model(['Product_model','Stock_opname_model']);
+        $this->load->library(['session','form_validation']);
+        $this->load->helper(['url','form']);
+    }
+
+    private function authorize()
+    {
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+        $role = $this->session->userdata('role');
+        if (!in_array($role, ['admin_keuangan','owner'])) {
+            redirect('dashboard');
+        }
+    }
+
+    /**
+     * Tampilkan form stock opname.
+     */
+    public function index()
+    {
+        $this->authorize();
+        $data['products'] = $this->Product_model->get_all();
+        $this->load->view('stock_opname/index', $data);
+    }
+
+    /**
+     * Simpan hasil stock opname.
+     */
+    public function save()
+    {
+        $this->authorize();
+        $physical = $this->input->post('physical');
+        if (!$physical) {
+            redirect('stock_opname');
+            return;
+        }
+        $timestamp = date('Y-m-d H:i:s');
+        $batch = [];
+        foreach ($physical as $product_id => $phys) {
+            $product = $this->Product_model->get_by_id($product_id);
+            if (!$product) {
+                continue;
+            }
+            $system = (int) $product->stok;
+            $phys = (int) $phys;
+            $diff = $phys - $system;
+            $batch[] = [
+                'product_id'  => $product_id,
+                'stok_sistem' => $system,
+                'stok_fisik'  => $phys,
+                'selisih'     => $diff,
+                'opname_at'   => $timestamp
+            ];
+            // update stok produk sesuai jumlah fisik
+            $this->Product_model->update($product_id, ['stok' => $phys]);
+        }
+        if ($batch) {
+            $this->Stock_opname_model->insert_batch($batch);
+        }
+        $this->session->set_flashdata('success', 'Stok opname berhasil disimpan.');
+        redirect('stock_opname/report?at='.urlencode($timestamp));
+    }
+
+    /**
+     * Laporan selisih setelah stock opname.
+     */
+    public function report()
+    {
+        $this->authorize();
+        $timestamp = $this->input->get('at');
+        $data['records'] = $this->Stock_opname_model->get_report($timestamp);
+        $this->load->view('stock_opname/report', $data);
+    }
+}

--- a/application/models/Stock_opname_model.php
+++ b/application/models/Stock_opname_model.php
@@ -1,0 +1,26 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Model untuk menyimpan hasil stock opname.
+ */
+class Stock_opname_model extends CI_Model
+{
+    protected $table = 'stock_opnames';
+
+    public function insert_batch($data)
+    {
+        return $this->db->insert_batch($this->table, $data);
+    }
+
+    public function get_report($timestamp)
+    {
+        $this->db->select('s.*, p.nama_produk');
+        $this->db->from($this->table . ' s');
+        $this->db->join('products p', 'p.id = s.product_id');
+        if ($timestamp) {
+            $this->db->where('s.opname_at', $timestamp);
+        }
+        return $this->db->get()->result();
+    }
+}

--- a/application/views/stock_opname/index.php
+++ b/application/views/stock_opname/index.php
@@ -1,0 +1,41 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Stock Opname</h2>
+<?php if ($this->session->flashdata('success')): ?>
+    <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
+<?php endif; ?>
+<form method="post" action="<?php echo site_url('stock_opname/save'); ?>">
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Nama Produk</th>
+            <th>Stok Sistem</th>
+            <th>Jumlah Fisik</th>
+            <th>Selisih</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($products as $product): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($product->nama_produk); ?></td>
+            <td><?php echo $product->stok; ?></td>
+            <td>
+                <input type="number" name="physical[<?php echo $product->id; ?>]" class="form-control physical-input" data-system="<?php echo $product->stok; ?>" required>
+            </td>
+            <td class="difference">0</td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<button type="submit" class="btn btn-primary">Simpan</button>
+</form>
+<script>
+document.querySelectorAll('.physical-input').forEach(function(input){
+    input.addEventListener('input', function(){
+        var system = parseInt(this.getAttribute('data-system'), 10) || 0;
+        var physical = parseInt(this.value, 10) || 0;
+        var diff = physical - system;
+        this.closest('tr').querySelector('.difference').textContent = diff;
+    });
+});
+</script>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/stock_opname/report.php
+++ b/application/views/stock_opname/report.php
@@ -1,0 +1,24 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Laporan Stock Opname</h2>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Nama Produk</th>
+            <th>Stok Sistem</th>
+            <th>Jumlah Fisik</th>
+            <th>Selisih</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($records as $row): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($row->nama_produk); ?></td>
+            <td><?php echo $row->stok_sistem; ?></td>
+            <td><?php echo $row->stok_fisik; ?></td>
+            <td><?php echo $row->selisih; ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<a href="<?php echo site_url('stock_opname'); ?>" class="btn btn-secondary">Kembali</a>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -48,6 +48,9 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
                             <a class="dropdown-item" href="<?php echo site_url('pos'); ?>">Tambah Transaksi</a>
                             <a class="dropdown-item" href="<?php echo site_url('pos/transactions'); ?>">Lihat Transaksi</a>
                             <a class="dropdown-item" href="<?php echo site_url('products'); ?>">Tambah Produk</a>
+                            <?php if (in_array($role, ['admin_keuangan','owner'])): ?>
+                                <a class="dropdown-item" href="<?php echo site_url('stock_opname'); ?>">Stock Opname</a>
+                            <?php endif; ?>
                         </div>
                     </li>
                 <?php endif; ?>

--- a/database.sql
+++ b/database.sql
@@ -572,6 +572,37 @@ ALTER TABLE `sales`
 ALTER TABLE `sale_details`
   ADD CONSTRAINT `sale_details_ibfk_1` FOREIGN KEY (`id_sale`) REFERENCES `sales` (`id`),
   ADD CONSTRAINT `sale_details_ibfk_2` FOREIGN KEY (`id_product`) REFERENCES `products` (`id`);
+
+--
+-- Table structure for table `stock_opnames`
+--
+CREATE TABLE `stock_opnames` (
+  `id` int(11) NOT NULL,
+  `product_id` int(11) NOT NULL,
+  `stok_sistem` int(11) NOT NULL,
+  `stok_fisik` int(11) NOT NULL,
+  `selisih` int(11) NOT NULL,
+  `opname_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Indexes for table `stock_opnames`
+--
+ALTER TABLE `stock_opnames`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `product_id` (`product_id`);
+
+--
+-- AUTO_INCREMENT for table `stock_opnames`
+--
+ALTER TABLE `stock_opnames`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- Constraints for table `stock_opnames`
+--
+ALTER TABLE `stock_opnames`
+  ADD CONSTRAINT `stock_opnames_ibfk_1` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`);
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;


### PR DESCRIPTION
## Summary
- add Stock_opname controller and model to manage physical stock counts
- add views for performing and reporting stock opname
- expose Stock Opname menu for admin and owner roles and create database table

## Testing
- `php -l application/controllers/Stock_opname.php`
- `php -l application/models/Stock_opname_model.php`
- `php -l application/views/stock_opname/index.php`
- `php -l application/views/stock_opname/report.php`
- `php -l application/views/templates/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68be45b761b88320b2ea6d461774e24b