### PR TITLE
Add stock opname feature for admin

### DIFF
--- a/application/controllers/Stock_opname.php
+++ b/application/controllers/Stock_opname.php
@@ -1,0 +1,109 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Controller untuk proses stock opname produk.
+ */
+class Stock_opname extends CI_Controller
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->model(['Product_model','Stock_opname_model']);
+        $this->load->library(['session','form_validation']);
+        $this->load->helper(['url','form']);
+    }
+
+    private function authorize()
+    {
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+        $role = $this->session->userdata('role');
+        if (!in_array($role, ['admin_keuangan','owner'])) {
+            redirect('dashboard');
+        }
+    }
+
+    /**
+     * Tampilkan form stock opname.
+     */
+    public function index()
+    {
+        $this->authorize();
+
+        $kategori = $this->input->get('kategori');
+        $keyword  = $this->input->get('q');
+
+        $data['products'] = $this->Product_model->get_filtered($kategori, $keyword);
+        $data['categories'] = $this->Product_model->get_categories();
+        $data['selected_category'] = $kategori;
+        $data['search_query'] = $keyword;
+
+        $this->load->view('stock_opname/index', $data);
+    }
+
+    /**
+     * Simpan hasil stock opname.
+     */
+    public function save()
+    {
+        $this->authorize();
+        $physical = $this->input->post('physical');
+        if (!$physical) {
+            redirect('stock_opname');
+            return;
+        }
+        $timestamp = date('Y-m-d H:i:s');
+        $batch = [];
+        foreach ($physical as $product_id => $phys) {
+            $product = $this->Product_model->get_by_id($product_id);
+            if (!$product) {
+                continue;
+            }
+            $system = (int) $product->stok;
+            $phys = (int) $phys;
+            $diff = $phys - $system;
+            $batch[] = [
+                'product_id'  => $product_id,
+                'stok_sistem' => $system,
+                'stok_fisik'  => $phys,
+                'selisih'     => $diff,
+                'opname_at'   => $timestamp
+            ];
+            // stok produk tidak diperbarui di sini; hanya simpan data opname
+        }
+        if ($batch) {
+            $this->db->trans_start();
+            $this->Stock_opname_model->insert_batch($batch);
+            $this->Stock_opname_model->delete_except($timestamp);
+            $this->db->trans_complete();
+        }
+        $this->session->set_flashdata('success', 'Data opname berhasil disimpan.');
+        redirect('stock_opname/report');
+    }
+
+    /**
+     * Laporan selisih setelah stock opname.
+     */
+    public function report()
+    {
+        $this->authorize();
+        $data['records'] = $this->Stock_opname_model->get_report();
+        $this->load->view('stock_opname/report', $data);
+    }
+
+    /**
+     * Endpoint AJAX untuk mengambil daftar produk terfilter.
+     */
+    public function search()
+    {
+        $this->authorize();
+        $kategori = $this->input->get('kategori');
+        $keyword  = $this->input->get('q');
+        $products = $this->Product_model->get_filtered($kategori, $keyword);
+        $this->output
+            ->set_content_type('application/json')
+            ->set_output(json_encode($products));
+    }
+}

--- a/application/models/Stock_opname_model.php
+++ b/application/models/Stock_opname_model.php
@@ -1,0 +1,29 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Model untuk menyimpan hasil stock opname.
+ */
+class Stock_opname_model extends CI_Model
+{
+    protected $table = 'stock_opnames';
+
+    public function insert_batch($data)
+    {
+        return $this->db->insert_batch($this->table, $data);
+    }
+
+    public function get_report()
+    {
+        $this->db->select('s.*, p.nama_produk');
+        $this->db->from($this->table . ' s');
+        $this->db->join('products p', 'p.id = s.product_id');
+        return $this->db->get()->result();
+    }
+
+    public function delete_except($timestamp)
+    {
+        $this->db->where('opname_at !=', $timestamp);
+        return $this->db->delete($this->table);
+    }
+}

--- a/application/views/stock_opname/index.php
+++ b/application/views/stock_opname/index.php
@@ -1,0 +1,222 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Stock Opname</h2>
+<?php if ($this->session->flashdata('success')): ?>
+    <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
+<?php endif; ?>
+
+<form class="form-inline mb-2" onsubmit="return false;">
+    <select name="kategori" id="category-filter" class="form-control mr-2">
+        <option value="">Semua Kategori</option>
+        <?php foreach ($categories as $c): ?>
+            <option value="<?php echo $c; ?>" <?php echo ($selected_category == $c) ? 'selected' : ''; ?>><?php echo htmlspecialchars($c); ?></option>
+        <?php endforeach; ?>
+    </select>
+    <input type="text" name="q" id="product-search" value="<?php echo htmlspecialchars($search_query); ?>" class="form-control" placeholder="Cari produk">
+</form>
+
+<form id="stock-form" method="post" action="<?php echo site_url('stock_opname/save'); ?>">
+<table class="table table-bordered" id="products-table">
+    <thead>
+        <tr>
+            <th>Nama Produk</th>
+            <th>Kategori</th>
+            <th>Stok Sistem</th>
+            <th>Jumlah Fisik</th>
+            <th>Selisih</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($products as $product): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($product->nama_produk); ?></td>
+            <td><?php echo htmlspecialchars($product->kategori); ?></td>
+            <td><?php echo $product->stok; ?></td>
+            <td>
+                <input type="number" name="physical[<?php echo $product->id; ?>]" class="form-control physical-input" data-system="<?php echo $product->stok; ?>" required>
+            </td>
+            <td class="difference">0</td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<div class="d-flex justify-content-between align-items-center">
+    <div>
+        <select id="product-rows-per-page" class="custom-select w-auto d-inline-block">
+            <option value="10">10</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+            <option value="100">100</option>
+        </select>
+    </div>
+    <nav>
+        <ul id="product-pagination" class="pagination mb-0"></ul>
+    </nav>
+</div>
+<button type="submit" class="btn btn-primary mt-2">Simpan Data Opname</button>
+</form>
+
+<script>
+var searchInput = document.getElementById('product-search');
+var categorySelect = document.getElementById('category-filter');
+var productsBody = document.querySelector('#products-table tbody');
+var rowsPerPageSelect = document.getElementById('product-rows-per-page');
+var pagination = document.getElementById('product-pagination');
+var searchUrl = '<?php echo site_url('stock_opname/search'); ?>';
+var stockForm = document.getElementById('stock-form');
+var physicalValues = {};
+
+function attachDiffListeners() {
+    if (!productsBody) return;
+    productsBody.querySelectorAll('.physical-input').forEach(function(input){
+        input.addEventListener('input', function(){
+            var system = parseInt(this.getAttribute('data-system'), 10) || 0;
+            var physical = parseInt(this.value, 10) || 0;
+            var diff = physical - system;
+            this.closest('tr').querySelector('.difference').textContent = diff;
+            var idMatch = this.name.match(/physical\[(\d+)\]/);
+            if (idMatch) {
+                physicalValues[idMatch[1]] = this.value;
+            }
+        });
+    });
+}
+
+function renderProducts(items) {
+    productsBody.innerHTML = '';
+    items.forEach(function(p){
+        var stored = physicalValues[p.id] !== undefined ? physicalValues[p.id] : '';
+        var diff = stored ? (parseInt(stored, 10) - parseInt(p.stok, 10)) : 0;
+        var tr = document.createElement('tr');
+        tr.innerHTML = '<td>' + p.nama_produk + '</td>' +
+                       '<td>' + (p.kategori || '') + '</td>' +
+                       '<td>' + p.stok + '</td>' +
+                       '<td><input type="number" name="physical[' + p.id + ']" class="form-control physical-input" data-system="' + p.stok + '" value="' + stored + '" required></td>' +
+                       '<td class="difference">' + diff + '</td>';
+        productsBody.appendChild(tr);
+    });
+    attachDiffListeners();
+    setupProductPagination();
+}
+
+function setupProductPagination() {
+    if (!productsBody || !rowsPerPageSelect || !pagination) return;
+    var allRows = Array.from(productsBody.querySelectorAll('tr'));
+    var rows = allRows.slice();
+    var rowsPerPage = parseInt(rowsPerPageSelect.value, 10);
+    var pageCount = Math.ceil(rows.length / rowsPerPage) || 1;
+    var currentPage = 1;
+
+    function displayPage(page) {
+        currentPage = page;
+        var start = (page - 1) * rowsPerPage;
+        var end = start + rowsPerPage;
+        allRows.forEach(function(row){ row.style.display = 'none'; });
+        rows.slice(start, end).forEach(function(row){ row.style.display = ''; });
+        pagination.innerHTML = '';
+
+        var maxLinks = 5;
+        var startPage = Math.max(1, currentPage - Math.floor(maxLinks / 2));
+        var endPage = Math.min(pageCount, startPage + maxLinks - 1);
+        startPage = Math.max(1, endPage - maxLinks + 1);
+
+        function createItem(label, targetPage, disabled) {
+            var li = document.createElement('li');
+            li.className = 'page-item' + (disabled ? ' disabled' : '');
+            var a = document.createElement('a');
+            a.className = 'page-link';
+            a.href = '#';
+            a.textContent = label;
+            if (!disabled) {
+                a.addEventListener('click', function(e){
+                    e.preventDefault();
+                    displayPage(targetPage);
+                });
+            }
+            li.appendChild(a);
+            pagination.appendChild(li);
+        }
+
+        createItem('First', 1, currentPage === 1);
+        createItem('Prev', currentPage - 1, currentPage === 1);
+
+        for (var i = startPage; i <= endPage; i++) {
+            var li = document.createElement('li');
+            li.className = 'page-item' + (i === currentPage ? ' active' : '');
+            var a = document.createElement('a');
+            a.className = 'page-link';
+            a.href = '#';
+            a.textContent = i;
+            (function(i){
+                a.addEventListener('click', function(e){
+                    e.preventDefault();
+                    displayPage(i);
+                });
+            })(i);
+            li.appendChild(a);
+            pagination.appendChild(li);
+        }
+
+        createItem('Next', currentPage + 1, currentPage === pageCount);
+        createItem('Last', pageCount, currentPage === pageCount);
+    }
+
+    displayPage(1);
+}
+
+function updateProducts() {
+    if (productsBody) {
+        productsBody.querySelectorAll('.physical-input').forEach(function(inp){
+            var idMatch = inp.name.match(/physical\[(\d+)\]/);
+            if (idMatch) {
+                physicalValues[idMatch[1]] = inp.value;
+            }
+        });
+    }
+    var params = new URLSearchParams();
+    if (categorySelect.value) params.append('kategori', categorySelect.value);
+    if (searchInput.value) params.append('q', searchInput.value);
+    fetch(searchUrl + '?' + params.toString())
+        .then(function(r){ return r.json(); })
+        .then(renderProducts);
+}
+
+if (stockForm) {
+    stockForm.addEventListener('submit', function(){
+        if (productsBody) {
+            productsBody.querySelectorAll('.physical-input').forEach(function(inp){
+                var idMatch = inp.name.match(/physical\[(\d+)\]/);
+                if (idMatch) {
+                    physicalValues[idMatch[1]] = inp.value;
+                }
+            });
+        }
+        this.querySelectorAll('.hidden-physical').forEach(function(el){ el.remove(); });
+        for (var id in physicalValues) {
+            if (!physicalValues.hasOwnProperty(id)) continue;
+            if (!this.querySelector('input[name="physical[' + id + ']"]')) {
+                var hidden = document.createElement('input');
+                hidden.type = 'hidden';
+                hidden.name = 'physical[' + id + ']';
+                hidden.value = physicalValues[id];
+                hidden.className = 'hidden-physical';
+                this.appendChild(hidden);
+            } else {
+                this.querySelector('input[name="physical[' + id + ']"]').value = physicalValues[id];
+            }
+        }
+    });
+}
+
+if (searchInput && categorySelect) {
+    searchInput.addEventListener('input', updateProducts);
+    categorySelect.addEventListener('change', updateProducts);
+}
+
+if (rowsPerPageSelect && pagination && productsBody) {
+    rowsPerPageSelect.addEventListener('change', setupProductPagination);
+    setupProductPagination();
+}
+
+attachDiffListeners();
+</script>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/stock_opname/report.php
+++ b/application/views/stock_opname/report.php
@@ -1,0 +1,74 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Laporan Stock Opname</h2>
+
+<div class="mb-3">
+    <label for="selisihFilter" class="mr-2">Filter:</label>
+    <select id="selisihFilter" class="form-control w-auto d-inline-block">
+        <option value="all">Semua</option>
+        <option value="diff">Ada Selisih</option>
+    </select>
+</div>
+
+<table id="stockOpnameReportTable" class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Nama Produk</th>
+            <th>Stok Sistem</th>
+            <th>Jumlah Fisik</th>
+            <th>Selisih</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($records as $row): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($row->nama_produk); ?></td>
+            <td><?php echo $row->stok_sistem; ?></td>
+            <td><?php echo $row->stok_fisik; ?></td>
+            <td><?php echo $row->selisih; ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+
+<div class="mt-3">
+    <button id="exportPdf" class="btn btn-secondary">Export PDF</button>
+    <button id="exportExcel" class="btn btn-success ml-2">Export Excel</button>
+</div>
+
+<a href="<?php echo site_url('stock_opname'); ?>" class="btn btn-secondary mt-3">Kembali</a>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+<script>
+document.getElementById('selisihFilter').addEventListener('change', function () {
+    const showDiffOnly = this.value === 'diff';
+    const rows = document.querySelectorAll('#stockOpnameReportTable tbody tr');
+    rows.forEach(row => {
+        const diff = parseFloat(row.cells[3].textContent);
+        if (showDiffOnly && diff === 0) {
+            row.style.display = 'none';
+        } else {
+            row.style.display = '';
+        }
+    });
+});
+
+document.getElementById('exportPdf').addEventListener('click', function () {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    doc.text('Laporan Stock Opname', 14, 15);
+    doc.autoTable({ html: '#stockOpnameReportTable', startY: 20 });
+    doc.save('laporan_stock_opname.pdf');
+});
+
+document.getElementById('exportExcel').addEventListener('click', function () {
+    const table = document.getElementById('stockOpnameReportTable');
+    const wb = XLSX.utils.book_new();
+    const ws = XLSX.utils.table_to_sheet(table);
+    XLSX.utils.book_append_sheet(wb, ws, 'Stock Opname');
+    XLSX.writeFile(wb, 'laporan_stock_opname.xlsx');
+});
+</script>
+
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -48,6 +48,9 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
                             <a class="dropdown-item" href="<?php echo site_url('pos'); ?>">Tambah Transaksi</a>
                             <a class="dropdown-item" href="<?php echo site_url('pos/transactions'); ?>">Lihat Transaksi</a>
                             <a class="dropdown-item" href="<?php echo site_url('products'); ?>">Tambah Produk</a>
+                            <?php if (in_array($role, ['admin_keuangan','owner'])): ?>
+                                <a class="dropdown-item" href="<?php echo site_url('stock_opname'); ?>">Stock Opname</a>
+                            <?php endif; ?>
                         </div>
                     </li>
                 <?php endif; ?>
@@ -65,6 +68,9 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
                             <a class="dropdown-item" href="<?php echo site_url('finance'); ?>">Laporan Keuangan</a>
                             <a class="dropdown-item" href="<?php echo site_url('point_report'); ?>">Laporan Tukar Poin</a>
                             <a class="dropdown-item" href="<?php echo site_url('pos/cancelled'); ?>">Laporan Batal Transaksi</a>
+                            <?php if (in_array($role, ['admin_keuangan','owner'])): ?>
+                                <a class="dropdown-item" href="<?php echo site_url('stock_opname/report'); ?>">Laporan Stock Opname</a>
+                            <?php endif; ?>
                             <?php if ($role === 'owner'): ?>
                                 <a class="dropdown-item" href="<?php echo site_url('reports'); ?>">Laporan Bisnis</a>
                             <?php endif; ?>

--- a/database.sql
+++ b/database.sql
@@ -572,6 +572,37 @@ ALTER TABLE `sales`
 ALTER TABLE `sale_details`
   ADD CONSTRAINT `sale_details_ibfk_1` FOREIGN KEY (`id_sale`) REFERENCES `sales` (`id`),
   ADD CONSTRAINT `sale_details_ibfk_2` FOREIGN KEY (`id_product`) REFERENCES `products` (`id`);
+
+--
+-- Table structure for table `stock_opnames`
+--
+CREATE TABLE `stock_opnames` (
+  `id` int(11) NOT NULL,
+  `product_id` int(11) NOT NULL,
+  `stok_sistem` int(11) NOT NULL,
+  `stok_fisik` int(11) NOT NULL,
+  `selisih` int(11) NOT NULL,
+  `opname_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Indexes for table `stock_opnames`
+--
+ALTER TABLE `stock_opnames`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `product_id` (`product_id`);
+
+--
+-- AUTO_INCREMENT for table `stock_opnames`
+--
+ALTER TABLE `stock_opnames`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- Constraints for table `stock_opnames`
+--
+ALTER TABLE `stock_opnames`
+  ADD CONSTRAINT `stock_opnames_ibfk_1` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`);
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;


### PR DESCRIPTION
## Summary
- add Stock_opname controller and model to manage physical stock counts
- add views for performing and reporting stock opname with category filters, search, and pagination
- expose Stock Opname menu for admin and owner roles and create database table
- add stock opname report navigation with PDF and Excel export options
- preserve entered physical counts when changing category filters by caching values and restoring them on render
- stop Save action from updating product stock; only record physical counts and rename button to "Simpan Data Opname"
- clear previous stock opname data on save so the report only shows the latest results
- add filter in report view to show only products with a stock difference

## Testing
- `php -l application/controllers/Stock_opname.php`
- `php -l application/models/Stock_opname_model.php`
- `php -l application/views/stock_opname/index.php`
- `php -l application/views/stock_opname/report.php`


------
https://chatgpt.com/codex/tasks/task_e_68be45b761b88320b2ea6d461774e24b