### PR TITLE
Hide out-of-stock products in POS

### DIFF
--- a/application/models/Product_model.php
+++ b/application/models/Product_model.php
@@ -70,6 +70,7 @@ class Product_model extends CI_Model
      */
     public function get_filtered($kategori = null, $keyword = null)
     {
+        $this->db->where('stok >', 0);
         if ($kategori) {
             $this->db->where('kategori', $kategori);
         }


### PR DESCRIPTION
## Summary
- hide products with zero stock from POS product list

## Testing
- `composer test:coverage` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be6ac7dff48320a0c6b509c89201f5