### PR TITLE
Add manual stock management and reporting

### DIFF
--- a/application/controllers/Manual_stock.php
+++ b/application/controllers/Manual_stock.php
@@ -1,0 +1,94 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Controller untuk manajemen stok manual dan laporan stok masuk/keluar.
+ */
+class Manual_stock extends CI_Controller
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->model(['Product_model','Stock_manual_model']);
+        $this->load->library(['session','form_validation']);
+        $this->load->helper(['url','form']);
+    }
+
+    private function authorize()
+    {
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+        $role = $this->session->userdata('role');
+        if (!in_array($role, ['kasir','admin_keuangan','owner'])) {
+            redirect('dashboard');
+        }
+    }
+
+    /**
+     * Tampilkan form manajemen stok manual.
+     */
+    public function index()
+    {
+        $this->authorize();
+        $data['products'] = $this->Product_model->get_all();
+        $this->load->view('manual_stock/index', $data);
+    }
+
+    /**
+     * Simpan transaksi stok manual.
+     */
+    public function save()
+    {
+        $this->authorize();
+        $product_id = (int) $this->input->post('product_id');
+        $qty        = (int) $this->input->post('qty');
+        $type       = $this->input->post('type');
+        $note       = $this->input->post('note');
+
+        $product = $this->Product_model->get_by_id($product_id);
+        if (!$product || $qty <= 0 || !in_array($type, ['Tambah','Ambil'])) {
+            $this->session->set_flashdata('error', 'Data tidak valid.');
+            redirect('manual_stock');
+            return;
+        }
+
+        $this->db->trans_start();
+        if ($type === 'Tambah') {
+            $this->Product_model->increase_stock($product_id, $qty);
+        } else {
+            $this->Product_model->decrease_stock($product_id, $qty);
+        }
+        $updated = $this->Product_model->get_by_id($product_id);
+        $log = [
+            'product_id' => $product_id,
+            'type'       => strtolower($type),
+            'quantity'   => $qty,
+            'note'       => $note,
+            'total_stock'=> $updated ? $updated->stok : 0,
+            'created_at' => date('Y-m-d H:i:s')
+        ];
+        $this->Stock_manual_model->insert($log);
+        $this->db->trans_complete();
+
+        $this->session->set_flashdata('success', 'Transaksi stok berhasil disimpan.');
+        redirect('manual_stock');
+    }
+
+    /**
+     * Laporan stok masuk/keluar.
+     */
+    public function report()
+    {
+        $this->authorize();
+        $start   = $this->input->get('start');
+        $end     = $this->input->get('end');
+        $keyword = $this->input->get('q');
+
+        $data['records'] = $this->Stock_manual_model->get_report($start, $end, $keyword);
+        $data['filter_start'] = $start;
+        $data['filter_end']   = $end;
+        $data['search_query'] = $keyword;
+        $this->load->view('manual_stock/report', $data);
+    }
+}

--- a/application/models/Product_model.php
+++ b/application/models/Product_model.php
@@ -70,6 +70,7 @@ class Product_model extends CI_Model
      */
     public function get_filtered($kategori = null, $keyword = null)
     {
+        $this->db->where('stok >', 0);
         if ($kategori) {
             $this->db->where('kategori', $kategori);
         }

--- a/application/models/Stock_manual_model.php
+++ b/application/models/Stock_manual_model.php
@@ -1,0 +1,33 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Model untuk mencatat transaksi stok manual.
+ */
+class Stock_manual_model extends CI_Model
+{
+    protected $table = 'manual_stock_logs';
+
+    public function insert($data)
+    {
+        return $this->db->insert($this->table, $data);
+    }
+
+    public function get_report($start = null, $end = null, $keyword = null)
+    {
+        $this->db->select('l.*, p.nama_produk');
+        $this->db->from($this->table . ' l');
+        $this->db->join('products p', 'p.id = l.product_id');
+        if ($start) {
+            $this->db->where('DATE(l.created_at) >=', $start);
+        }
+        if ($end) {
+            $this->db->where('DATE(l.created_at) <=', $end);
+        }
+        if ($keyword) {
+            $this->db->like('p.nama_produk', $keyword);
+        }
+        $this->db->order_by('l.created_at', 'DESC');
+        return $this->db->get()->result();
+    }
+}

--- a/application/views/manual_stock/index.php
+++ b/application/views/manual_stock/index.php
@@ -1,0 +1,39 @@
+<?php $this->load->view('templates/header'); ?>
+<?php $this->load->view('store/overlay'); ?>
+<h2>Manajemen Stok Manual</h2>
+<?php if ($this->session->flashdata('success')): ?>
+    <div class="alert alert-success"><?php echo $this->session->flashdata('success'); ?></div>
+<?php endif; ?>
+<?php if ($this->session->flashdata('error')): ?>
+    <div class="alert alert-danger"><?php echo $this->session->flashdata('error'); ?></div>
+<?php endif; ?>
+<form method="post" action="<?php echo site_url('manual_stock/save'); ?>" class="mb-4">
+    <div class="form-row">
+        <div class="col-md-4">
+            <label for="product">Cari Produk</label>
+            <input list="products" name="product_id" id="product" class="form-control" required>
+            <datalist id="products">
+                <?php foreach ($products as $p): ?>
+                <option value="<?php echo $p->id; ?>"><?php echo htmlspecialchars($p->nama_produk); ?></option>
+                <?php endforeach; ?>
+            </datalist>
+        </div>
+        <div class="col-md-2">
+            <label for="qty">Jumlah</label>
+            <input type="number" name="qty" id="qty" min="1" class="form-control" required>
+        </div>
+        <div class="col-md-3">
+            <label for="type">Jenis Transaksi</label>
+            <select name="type" id="type" class="form-control" required>
+                <option value="Tambah">Tambah</option>
+                <option value="Ambil">Ambil</option>
+            </select>
+        </div>
+        <div class="col-md-3">
+            <label for="note">Keterangan</label>
+            <input type="text" name="note" id="note" class="form-control">
+        </div>
+    </div>
+    <button type="submit" class="btn btn-primary mt-3">Simpan</button>
+</form>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/manual_stock/report.php
+++ b/application/views/manual_stock/report.php
@@ -1,0 +1,36 @@
+<?php $this->load->view('templates/header'); ?>
+<h2>Laporan Stok Masuk/Keluar</h2>
+<form class="form-inline mb-3" method="get">
+    <label class="mr-2" for="start">Dari</label>
+    <input type="date" name="start" id="start" value="<?php echo htmlspecialchars($filter_start); ?>" class="form-control mr-2">
+    <label class="mr-2" for="end">Sampai</label>
+    <input type="date" name="end" id="end" value="<?php echo htmlspecialchars($filter_end); ?>" class="form-control mr-2">
+    <input type="text" name="q" placeholder="Cari produk" value="<?php echo htmlspecialchars($search_query); ?>" class="form-control mr-2">
+    <button type="submit" class="btn btn-primary">Filter</button>
+</form>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Tanggal</th>
+            <th>Nama Produk</th>
+            <th>Jenis Transaksi</th>
+            <th>Jumlah</th>
+            <th>Keterangan</th>
+            <th>Total Stok</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($records as $r): ?>
+        <tr>
+            <td><?php echo $r->created_at; ?></td>
+            <td><?php echo htmlspecialchars($r->nama_produk); ?></td>
+            <td><?php echo ucfirst($r->type); ?></td>
+            <td><?php echo $r->quantity; ?></td>
+            <td><?php echo htmlspecialchars($r->note); ?></td>
+            <td><?php echo $r->total_stock; ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<a href="<?php echo site_url('manual_stock'); ?>" class="btn btn-secondary mt-3">Kembali</a>
+<?php $this->load->view('templates/footer'); ?>

--- a/application/views/templates/header.php
+++ b/application/views/templates/header.php
@@ -48,6 +48,7 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
                             <a class="dropdown-item" href="<?php echo site_url('pos'); ?>">Tambah Transaksi</a>
                             <a class="dropdown-item" href="<?php echo site_url('pos/transactions'); ?>">Lihat Transaksi</a>
                             <a class="dropdown-item" href="<?php echo site_url('products'); ?>">Tambah Produk</a>
+                            <a class="dropdown-item" href="<?php echo site_url('manual_stock'); ?>">Manajemen Stok Manual</a>
                             <?php if (in_array($role, ['admin_keuangan','owner'])): ?>
                                 <a class="dropdown-item" href="<?php echo site_url('stock_opname'); ?>">Stock Opname</a>
                             <?php endif; ?>
@@ -68,6 +69,7 @@ $formatted_store_date = $store_date ? date('d-m-Y', strtotime($store_date)) : da
                             <a class="dropdown-item" href="<?php echo site_url('finance'); ?>">Laporan Keuangan</a>
                             <a class="dropdown-item" href="<?php echo site_url('point_report'); ?>">Laporan Tukar Poin</a>
                             <a class="dropdown-item" href="<?php echo site_url('pos/cancelled'); ?>">Laporan Batal Transaksi</a>
+                            <a class="dropdown-item" href="<?php echo site_url('manual_stock/report'); ?>">Laporan Stok Masuk/Keluar</a>
                             <?php if (in_array($role, ['admin_keuangan','owner'])): ?>
                                 <a class="dropdown-item" href="<?php echo site_url('stock_opname/report'); ?>">Laporan Stock Opname</a>
                             <?php endif; ?>

--- a/database.sql
+++ b/database.sql
@@ -603,6 +603,33 @@ ALTER TABLE `stock_opnames`
 --
 ALTER TABLE `stock_opnames`
   ADD CONSTRAINT `stock_opnames_ibfk_1` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`);
+
+-- --------------------------------------------------------
+
+-- Table structure for table `manual_stock_logs`
+--
+CREATE TABLE `manual_stock_logs` (
+  `id` int(11) NOT NULL,
+  `product_id` int(11) NOT NULL,
+  `type` enum('tambah','ambil') NOT NULL,
+  `quantity` int(11) NOT NULL,
+  `note` varchar(255) DEFAULT NULL,
+  `total_stock` int(11) NOT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+-- Indexes for table `manual_stock_logs`
+ALTER TABLE `manual_stock_logs`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `product_id` (`product_id`);
+
+-- AUTO_INCREMENT for table `manual_stock_logs`
+ALTER TABLE `manual_stock_logs`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+-- Constraints for table `manual_stock_logs`
+ALTER TABLE `manual_stock_logs`
+  ADD CONSTRAINT `manual_stock_logs_ibfk_1` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`);
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;


### PR DESCRIPTION
## Summary
- hide products with zero stock from POS product list
- add "Manajemen Stok Manual" page for cashiers to manually add or remove product stock
- record stock adjustments and expose "Laporan Stok Masuk/Keluar" report

## Testing
- `php -l application/controllers/Manual_stock.php`
- `php -l application/models/Stock_manual_model.php`
- `php -l application/views/manual_stock/index.php`
- `php -l application/views/manual_stock/report.php`
- `php -l application/views/templates/header.php`
- `composer test:coverage` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be6ac7dff48320a0c6b509c89201f5