### PR TITLE
Load store info in manual stock view

### DIFF
--- a/application/controllers/Manual_stock.php
+++ b/application/controllers/Manual_stock.php
@@ -9,7 +9,7 @@ class Manual_stock extends CI_Controller
     public function __construct()
     {
         parent::__construct();
-        $this->load->model(['Product_model','Stock_manual_model']);
+        $this->load->model(['Product_model','Stock_manual_model','Store_model']);
         $this->load->library(['session','form_validation']);
         $this->load->helper(['url','form']);
     }
@@ -32,6 +32,7 @@ class Manual_stock extends CI_Controller
     {
         $this->authorize();
         $data['products'] = $this->Product_model->get_all();
+        $data['store']    = $this->Store_model->get_current();
         $this->load->view('manual_stock/index', $data);
     }
 


### PR DESCRIPTION
## Summary
- Load `Store_model` in `Manual_stock` controller
- Pass current store status to the manual stock view

## Testing
- `php -l application/controllers/Manual_stock.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer run-script test:coverage` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be7188045c8320b294c561b66edf3b