### PR TITLE
Require complete customer data before checkout

### DIFF
--- a/application/controllers/Pos.php
+++ b/application/controllers/Pos.php
@@ -292,6 +292,14 @@ class Pos extends CI_Controller
         if (!is_numeric($customerId)) {
             $customerId = null;
         }
+        $customerName = trim($this->input->post('customer_name'));
+        $customerPhone = trim($this->input->post('customer_phone'));
+        $customerAddress = trim($this->input->post('customer_address'));
+        if ($customerName === '' || $customerPhone === '' || $customerAddress === '') {
+            $this->session->set_flashdata('error', 'Data customer tidak boleh kosong.');
+            redirect('pos');
+            return;
+        }
         $cart = $this->session->userdata('cart') ?: [];
         if (empty($cart)) {
             $this->session->set_flashdata('error', 'Keranjang kosong.');

--- a/application/models/Report_model.php
+++ b/application/models/Report_model.php
@@ -216,7 +216,7 @@ class Report_model extends CI_Model
             }
         } else { // booking atau batal
             $this->db->select(
-                "b.booking_code, b.tanggal_booking, b.harga_booking, b.diskon, b.total_harga, b.status_booking, u.nama_lengkap, m.kode_member, (b.harga_booking - b.diskon - b.total_harga) AS point_used",
+                "b.booking_code, b.tanggal_booking, b.harga_booking, b.diskon, b.total_harga, b.status_booking, b.customer_name, u.nama_lengkap, m.kode_member, (b.harga_booking - b.diskon - b.total_harga) AS point_used",
                 false
             );
             $this->db->from('bookings b');
@@ -231,12 +231,15 @@ class Report_model extends CI_Model
             }
             $rows = $this->db->get()->result();
             foreach ($rows as $r) {
+                $is_member    = !empty($r->kode_member);
+                $nama_member  = $is_member ? $r->nama_lengkap : (isset($r->customer_name) ? $r->customer_name : '');
+                $nomor_member = $is_member ? $r->kode_member : 'non member';
                 $details[] = [
                     'tanggal'        => $r->tanggal_booking,
                     'kode_booking'   => $r->booking_code,
                     'tanggal_booking'=> $r->tanggal_booking,
-                    'nama_member'    => $r->nama_lengkap,
-                    'nomor_member'   => $r->kode_member,
+                    'nama_member'    => $nama_member,
+                    'nomor_member'   => $nomor_member,
                     'poin_dipakai'   => (int) $r->point_used,
                     'diskon'         => (float) $r->diskon,
                     'total_harga'    => (float) $r->total_harga,

--- a/application/views/pos/index.php
+++ b/application/views/pos/index.php
@@ -79,6 +79,8 @@
                                     <div class="input-group input-group-sm">
                                         <input type="text" name="customer_name" id="customer-name" class="form-control" readonly form="checkout-form">
                                         <input type="hidden" name="customer_id" id="customer-id" form="checkout-form">
+                                        <input type="hidden" name="customer_phone" id="customer-phone-hidden" form="checkout-form">
+                                        <input type="hidden" name="customer_address" id="customer-address-hidden" form="checkout-form">
                                         <div class="input-group-append">
                                             <button type="button" class="btn btn-secondary" data-toggle="modal" data-target="#memberModal">Pilih</button>
                                         </div>
@@ -324,9 +326,13 @@ var chooseBtn = document.getElementById('choose-member');
 var lookupUrl = '<?php echo site_url('pos/member_lookup'); ?>';
 var customerIdInput = document.getElementById('customer-id');
 var customerNameInput = document.getElementById('customer-name');
+var customerPhoneHidden = document.getElementById('customer-phone-hidden');
+var customerAddressHidden = document.getElementById('customer-address-hidden');
 if (typeSelect && typeSelect.value === 'non') {
     numberInput.value = 'non member';
     if (customerIdInput) customerIdInput.value = '';
+    if (customerPhoneHidden) customerPhoneHidden.value = '';
+    if (customerAddressHidden) customerAddressHidden.value = '';
 }
 
 if (typeSelect) {
@@ -341,6 +347,8 @@ if (typeSelect) {
             phoneInput.value = '';
             addressInput.value = '';
             if (customerIdInput) customerIdInput.value = '';
+            if (customerPhoneHidden) customerPhoneHidden.value = '';
+            if (customerAddressHidden) customerAddressHidden.value = '';
             numberInput.focus();
         } else {
             numberInput.value = 'non member';
@@ -352,6 +360,8 @@ if (typeSelect) {
             phoneInput.value = '';
             addressInput.value = '';
             if (customerIdInput) customerIdInput.value = '';
+            if (customerPhoneHidden) customerPhoneHidden.value = '';
+            if (customerAddressHidden) customerAddressHidden.value = '';
         }
     });
 }
@@ -368,11 +378,15 @@ if (numberInput) {
                         nameInput.value = m.nama_lengkap;
                         phoneInput.value = m.no_telepon || '';
                         addressInput.value = m.alamat || '';
+                        if (customerPhoneHidden) customerPhoneHidden.value = m.no_telepon || '';
+                        if (customerAddressHidden) customerAddressHidden.value = m.alamat || '';
                     } else {
                         if (customerIdInput) customerIdInput.value = '';
                         nameInput.value = '';
                         phoneInput.value = '';
                         addressInput.value = '';
+                        if (customerPhoneHidden) customerPhoneHidden.value = '';
+                        if (customerAddressHidden) customerAddressHidden.value = '';
                     }
                 });
         } else {
@@ -380,6 +394,8 @@ if (numberInput) {
             nameInput.value = '';
             phoneInput.value = '';
             addressInput.value = '';
+            if (customerPhoneHidden) customerPhoneHidden.value = '';
+            if (customerAddressHidden) customerAddressHidden.value = '';
         }
     });
 }
@@ -387,6 +403,8 @@ if (numberInput) {
 if (chooseBtn && customerNameInput) {
     chooseBtn.addEventListener('click', function() {
         customerNameInput.value = nameInput.value;
+        if (customerPhoneHidden) customerPhoneHidden.value = phoneInput.value;
+        if (customerAddressHidden) customerAddressHidden.value = addressInput.value;
         $('#memberModal').modal('hide');
     });
 }


### PR DESCRIPTION
## Summary
- include hidden customer phone and address fields in POS cart
- populate hidden customer fields via JavaScript
- validate customer data on checkout and block submission if missing
- display non-member name and 'non member' number in finance report detail bookings

## Testing
- ⚠️ `composer install` (curl error 56: CONNECT tunnel failed, response 403)
- ⚠️ `composer test:coverage` (phpunit: not found)


------
https://chatgpt.com/codex/tasks/task_e_68beeeff0880832083d28300e5d6ae03