### PR TITLE
Fix non-member booking info in financial report and receipts

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -176,8 +176,10 @@ class Booking extends CI_Controller
             if ($total < 0) {
                 $total = 0;
             }
-            $pakai_poin = (int) $this->input->post('pakai_poin');
-            $id_user = $this->session->userdata('id');
+            $pakai_poin   = (int) $this->input->post('pakai_poin');
+            $id_user      = $this->session->userdata('id');
+            $customer_name = null;
+            $member_number = null;
             if ($this->session->userdata('role') === 'kasir') {
                 $type = $this->input->post('customer_type');
                 if ($type === 'member') {
@@ -205,6 +207,15 @@ class Booking extends CI_Controller
                         $poin_awal  = $saldo;
                         $poin_akhir = $saldo - $pakai_poin;
                     }
+                } else {
+                    $customer_name = trim($this->input->post('customer_name'));
+                    if ($customer_name === '') {
+                        $this->session->set_flashdata('error', 'Nama pelanggan wajib diisi.');
+                        redirect('booking/create');
+                        return;
+                    }
+                    $id_user = null;
+                    $member_number = 'non member';
                 }
             }
             if ($total < 0) {
@@ -247,6 +258,10 @@ class Booking extends CI_Controller
                 'status_booking'   => 'pending',
                 'status_pembayaran'=> 'belum_bayar'
             ];
+            if ($customer_name !== null) {
+                $data['customer_name'] = $customer_name;
+                $data['member_number'] = $member_number;
+            }
             if ($bukti_file) {
                 $data['bukti_pembayaran'] = $bukti_file;
             }
@@ -355,8 +370,12 @@ class Booking extends CI_Controller
         $lines[] = str_pad('Padel Store', $lineWidth, ' ', STR_PAD_BOTH);
         $lines[] = str_pad(date('d-m-Y H:i'), $lineWidth, ' ', STR_PAD_BOTH);
         if ($member && !empty($member->kode_member)) {
+            $lines[] = str_pad('Nama: ' . $member->nama_lengkap, $lineWidth, ' ', STR_PAD_BOTH);
             $lines[] = str_pad('Nomor Member: ' . $member->kode_member, $lineWidth, ' ', STR_PAD_BOTH);
         } else {
+            if (!empty($booking->customer_name)) {
+                $lines[] = str_pad('Nama: ' . $booking->customer_name, $lineWidth, ' ', STR_PAD_BOTH);
+            }
             $lines[] = str_pad('-Non Member-', $lineWidth, ' ', STR_PAD_BOTH);
         }
         $lines[] = str_repeat('-', $lineWidth);

--- a/database.sql
+++ b/database.sql
@@ -31,7 +31,9 @@ SET time_zone = "+00:00";
 CREATE TABLE `bookings` (
   `id` int(11) NOT NULL,
   `booking_code` varchar(20) NOT NULL,
-  `id_user` int(11) NOT NULL,
+  `id_user` int(11) DEFAULT NULL,
+  `customer_name` varchar(100) DEFAULT NULL,
+  `member_number` varchar(100) DEFAULT NULL,
   `id_court` int(11) NOT NULL,
   `tanggal_booking` date NOT NULL,
   `jam_mulai` time NOT NULL,
@@ -53,13 +55,13 @@ CREATE TABLE `bookings` (
 -- Dumping data for table `bookings`
 --
 
-INSERT INTO `bookings` (`id`, `booking_code`, `id_user`, `id_court`, `tanggal_booking`, `jam_mulai`, `jam_selesai`, `durasi`, `harga_booking`, `diskon`, `total_harga`, `poin_member`, `status_booking`, `keterangan`, `bukti_pembayaran`, `status_pembayaran`, `created_at`, `confirmed_at`) VALUES
-(1, '250826-0001', 1, 1, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 01:59:44', NULL),
-(2, '250826-0002', 1, 1, '2025-08-27', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:00:29', NULL),
-(3, '250825-0001', 3, 2, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-25 02:27:04', NULL),
-(4, '250825-0002', 3, 3, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'batal', '', NULL, 'belum_bayar', '2025-08-25 02:33:16', NULL),
-(5, '250826-0003', 1, 1, '2025-08-25', '14:00:00', '15:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'batal', '', NULL, 'belum_bayar', '2025-08-26 02:38:42', NULL),
-(6, '250826-0004', 1, 2, '2025-08-24', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:39:50', NULL);
+INSERT INTO `bookings` (`id`, `booking_code`, `id_user`, `customer_name`, `member_number`, `id_court`, `tanggal_booking`, `jam_mulai`, `jam_selesai`, `durasi`, `harga_booking`, `diskon`, `total_harga`, `poin_member`, `status_booking`, `keterangan`, `bukti_pembayaran`, `status_pembayaran`, `created_at`, `confirmed_at`) VALUES
+(1, '250826-0001', 1, NULL, NULL, 1, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 01:59:44', NULL),
+(2, '250826-0002', 1, NULL, NULL, 1, '2025-08-27', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:00:29', NULL),
+(3, '250825-0001', 3, NULL, NULL, 2, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-25 02:27:04', NULL),
+(4, '250825-0002', 3, NULL, NULL, 3, '2025-08-25', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'batal', '', NULL, 'belum_bayar', '2025-08-25 02:33:16', NULL),
+(5, '250826-0003', 1, NULL, NULL, 1, '2025-08-25', '14:00:00', '15:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'batal', '', NULL, 'belum_bayar', '2025-08-26 02:38:42', NULL),
+(6, '250826-0004', 1, NULL, NULL, 2, '2025-08-24', '13:00:00', '14:00:00', 60, '300000.00', '0.00', '300000.00', 0, 'pending', NULL, NULL, 'belum_bayar', '2025-08-26 02:39:50', NULL);
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- record non-member customer name and store `'non member'` marker during booking creation
- include stored non-member details in finance report queries and default missing member numbers to `'non member'`
- update SQL schema to support optional customer name/member number
- display customer name on booking receipts for both members and non-members, showing non-member names beneath the timestamp

## Testing
- `php -l application/controllers/Booking.php`
- `php -l application/models/Report_model.php`
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68befab2c62c8320ad13b15211f70f6e