### PR TITLE
Filter past booking slots on customer dashboard

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -44,6 +44,7 @@ class Dashboard extends CI_Controller
                 $courts         = $this->Court_model->get_all();
                 $start_hour     = 8;
                 $end_hour       = 23;
+                $now_time       = date('H:i:s');
                 foreach ($courts as $court) {
                     $bookings  = $this->Booking_model->get_by_court_and_date($court->id, $today);
                     $available = [];
@@ -57,7 +58,7 @@ class Dashboard extends CI_Controller
                                 break;
                             }
                         }
-                        if (!$occupied) {
+                        if (!$occupied && strtotime($slot_start) >= strtotime($now_time)) {
                             $available[] = [
                                 'start' => substr($slot_start, 0, 5),
                                 'end'   => substr($slot_end, 0, 5),


### PR DESCRIPTION
## Summary
- skip showing available slots that start earlier than the current time on the customer dashboard

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed 403)*
- `composer run-script test:coverage` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfabaf7cc88320905a1f814e3e39eb