### PR TITLE
Filter past booking slots on customer dashboard

### DIFF
--- a/application/controllers/Booking.php
+++ b/application/controllers/Booking.php
@@ -158,6 +158,13 @@ class Booking extends CI_Controller
                 $this->session->set_flashdata('error', 'Jam selesai harus lebih besar dari jam mulai.');
                 redirect('booking/create');
             }
+            $currentDate = date('Y-m-d');
+            $currentTime = date('H:i');
+            if ($date === $currentDate && strtotime($start) < strtotime($currentTime)) {
+                $this->session->set_flashdata('error', 'booking gagal, waktu booking tidak sesuai dengan waktu sekarang');
+                redirect('booking/create');
+                return;
+            }
             // Cek ketersediaan
             if (!$this->Booking_model->is_available($id_court, $date, $start, $end)) {
                 $this->session->set_flashdata('error', 'Lapangan sudah terbooking pada jam tersebut.');

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -44,6 +44,7 @@ class Dashboard extends CI_Controller
                 $courts         = $this->Court_model->get_all();
                 $start_hour     = 8;
                 $end_hour       = 23;
+                $now_time       = date('H:i:s');
                 foreach ($courts as $court) {
                     $bookings  = $this->Booking_model->get_by_court_and_date($court->id, $today);
                     $available = [];
@@ -57,7 +58,7 @@ class Dashboard extends CI_Controller
                                 break;
                             }
                         }
-                        if (!$occupied) {
+                        if (!$occupied && strtotime($slot_start) >= strtotime($now_time)) {
                             $available[] = [
                                 'start' => substr($slot_start, 0, 5),
                                 'end'   => substr($slot_end, 0, 5),

--- a/application/views/booking/create.php
+++ b/application/views/booking/create.php
@@ -192,6 +192,20 @@ if (numberInput) {
 var courtSelect = document.getElementById('id_court');
 var startInput = document.getElementById('jam_mulai');
 var endInput = document.getElementById('jam_selesai');
+var dateInput = document.getElementById('tanggal_booking');
+var todayStr = now.getFullYear() + '-' + ('0' + (now.getMonth() + 1)).slice(-2) + '-' + ('0' + now.getDate()).slice(-2);
+var nowTime = ('0' + now.getHours()).slice(-2) + ':' + ('0' + now.getMinutes()).slice(-2);
+function updateStartMin(){
+    if (startInput){
+        if (dateInput && dateInput.value === todayStr){
+            startInput.min = nowTime;
+        } else {
+            startInput.min = '08:00';
+        }
+    }
+}
+if (dateInput) dateInput.addEventListener('change', updateStartMin);
+updateStartMin();
 var hargaBookingInput = document.getElementById('harga-booking');
 var diskonPersenInput = document.getElementById('diskon-persen');
 var diskonRupiahInput = document.getElementById('diskon-rupiah');


### PR DESCRIPTION
## Summary
- skip showing available slots that start earlier than the current time on the customer dashboard
- block creating bookings for past time slots and notify users
- restrict booking form to times from now when the booking date is today

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed 403)*
- `composer run-script test:coverage` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfabaf7cc88320905a1f814e3e39eb